### PR TITLE
Fix incorrect API endpoints in RemoteConversation

### DIFF
--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -81,9 +81,7 @@ export class RemoteConversation {
   }
 
   async conversationStats(): Promise<ConversationStats> {
-    const response = await this.client.get<ConversationInfo>(
-      `/api/conversations/${this.id}`
-    );
+    const response = await this.client.get<ConversationInfo>(`/api/conversations/${this.id}`);
     return response.data.stats;
   }
 

--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -81,10 +81,10 @@ export class RemoteConversation {
   }
 
   async conversationStats(): Promise<ConversationStats> {
-    const response = await this.client.get<ConversationStats>(
-      `/api/conversations/${this.id}/stats`
+    const response = await this.client.get<ConversationInfo>(
+      `/api/conversations/${this.id}`
     );
-    return response.data;
+    return response.data.stats;
   }
 
   async sendMessage(message: string | Message): Promise<void> {
@@ -104,7 +104,7 @@ export class RemoteConversation {
       };
     }
 
-    await this.client.post(`/api/conversations/${this.id}/send_message`, messageContent);
+    await this.client.post(`/api/conversations/${this.id}/events`, messageContent);
   }
 
   async run(): Promise<void> {
@@ -116,12 +116,12 @@ export class RemoteConversation {
   }
 
   async setConfirmationPolicy(policy: ConfirmationPolicyBase): Promise<void> {
-    await this.client.post(`/api/conversations/${this.id}/set_confirmation_policy`, policy);
+    await this.client.post(`/api/conversations/${this.id}/confirmation_policy`, policy);
   }
 
   async sendConfirmationResponse(accept: boolean, reason?: string): Promise<void> {
     const request: ConfirmationResponseRequest = { accept, reason };
-    await this.client.post(`/api/conversations/${this.id}/send_confirmation_response`, request);
+    await this.client.post(`/api/conversations/${this.id}/events/respond_to_confirmation`, request);
   }
 
   async generateTitle(maxLength: number = 50, llm?: any): Promise<string> {
@@ -145,7 +145,7 @@ export class RemoteConversation {
     }
 
     const request: UpdateSecretsRequest = { secrets: secretStrings };
-    await this.client.post(`/api/conversations/${this.id}/update_secrets`, request);
+    await this.client.post(`/api/conversations/${this.id}/secrets`, request);
   }
 
   async startWebSocketClient(): Promise<void> {


### PR DESCRIPTION
## Summary

This PR fixes several incorrect API endpoints in the `RemoteConversation` class that were causing 404 errors because the endpoints didn't exist on the agent server.

## Changes Made

After analyzing the OpenAPI specification (`swagger-doc.json`) and comparing it with the current implementation, I identified and fixed the following incorrect endpoints:

### Fixed Endpoints

1. **`sendMessage`**: 
   - ❌ **Before**: `/api/conversations/{id}/send_message`
   - ✅ **After**: `/api/conversations/{id}/events`

2. **`setConfirmationPolicy`**: 
   - ❌ **Before**: `/api/conversations/{id}/set_confirmation_policy`
   - ✅ **After**: `/api/conversations/{id}/confirmation_policy`

3. **`sendConfirmationResponse`**: 
   - ❌ **Before**: `/api/conversations/{id}/send_confirmation_response`
   - ✅ **After**: `/api/conversations/{id}/events/respond_to_confirmation`

4. **`updateSecrets`**: 
   - ❌ **Before**: `/api/conversations/{id}/update_secrets`
   - ✅ **After**: `/api/conversations/{id}/secrets`

5. **`conversationStats`**: 
   - ❌ **Before**: `/api/conversations/{id}/stats` (endpoint doesn't exist)
   - ✅ **After**: Gets stats from `/api/conversations/{id}` response (stats are included in ConversationInfo)

### Endpoints That Were Already Correct

- ✅ `/api/conversations/{id}/run`
- ✅ `/api/conversations/{id}/pause`
- ✅ `/api/conversations/{id}/generate_title`
- ✅ `/api/conversations` (for creating conversations)
- ✅ `/api/conversations/{id}` (for getting conversation info)

## Testing

- ✅ TypeScript compilation passes (`npm run build`)
- ✅ All existing tests pass (`npm test`)
- ✅ ESLint passes with only existing warnings (no new errors)

## Impact

This fix ensures that the TypeScript client can successfully communicate with the OpenHands Agent Server without encountering 404 errors for these endpoints. All endpoints now match the official OpenAPI specification.

## References

- OpenAPI specification: `swagger-doc.json`
- Related to the agent server implementation in the `software-agent-sdk` repository

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3b9f19d232594c5ebb70f74b50d51b93)