### PR TITLE
Add agent behavior guidelines to prevent automatic server startup

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -66,6 +66,16 @@ state = conversation.state
 3. **Testing**: All functionality should be tested against a running OpenHands Agent Server instance
 4. **Documentation**: API changes should be reflected in the README.md and example code
 
+## Agent Behavior Guidelines
+
+**IMPORTANT**: The agent should NEVER start the server or browse to view the app unless the user explicitly asks for it. This includes:
+- Running development servers (e.g., `npm run dev`, `npm start`)
+- Opening browsers or navigating to application URLs
+- Starting any web servers or applications automatically
+- Viewing the running application in a browser
+
+The agent should focus on code development, testing, and documentation tasks. Only when the user specifically requests to run or view the application should the agent start servers or open browsers.
+
 ## Related Repositories
 
 - **[OpenHands/OpenHands](https://github.com/OpenHands/OpenHands)**: Core OpenHands application


### PR DESCRIPTION
## Summary

This PR adds important agent behavior guidelines to the repository documentation to prevent agents from automatically starting servers or browsing applications unless explicitly requested by users.

## Changes

- Added a new "Agent Behavior Guidelines" section to `.openhands/microagents/repo.md`
- Specified that agents should **NEVER** start servers or browse apps unless explicitly requested
- Included specific examples of prohibited automatic actions:
  - Running development servers (e.g., `npm run dev`, `npm start`)
  - Opening browsers or navigating to application URLs
  - Starting any web servers or applications automatically
  - Viewing the running application in a browser
- Clarified that agents should focus on code development, testing, and documentation tasks

## Rationale

This guideline ensures that agents working on this TypeScript client repository follow appropriate behavior patterns and don't automatically start services or open browsers, which could be disruptive or unexpected for users. Agents should only perform these actions when specifically requested.

## Impact

- Improves agent behavior consistency
- Prevents unexpected automatic server startups
- Provides clear guidance for future agent interactions with this repository

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7423721975564c2d81b6ec971bea68f1)