### PR TITLE
Fix example app to use user settings instead of hardcoded values

### DIFF
--- a/example/src/components/ConversationManager.tsx
+++ b/example/src/components/ConversationManager.tsx
@@ -79,9 +79,8 @@ export const ConversationManager: React.FC = () => {
       const agent: AgentBase = {
         name: 'CodeActAgent',
         llm: {
-          model: 'gpt-4o-mini',
-          api_key: settings.apiKey || '',
-          base_url: 'https://api.openai.com/v1'
+          model: settings.modelName,
+          api_key: settings.apiKey || ''
         }
       };
 


### PR DESCRIPTION
## Description

This PR fixes an issue in the example application where the ConversationManager component was hardcoding `gpt-4o-mini` as the model name instead of using the user's configured settings.

## Changes Made

- **Fixed hardcoded model**: Replaced hardcoded `'gpt-4o-mini'` with `settings.modelName` in the ConversationManager component
- **Removed base_url**: Removed the hardcoded `base_url: 'https://api.openai.com/v1'` from the LLM configuration to allow users to use their preferred provider settings

## Problem

The issue was introduced in commit `394ca3a47838c82afcae9e826b06d2bac7a81fa7` where the conversation creation logic was rewritten but accidentally hardcoded the model name instead of using the user's settings.

## Impact

- Users can now properly use their configured model name from the settings modal
- Users can use different LLM providers without being forced to use OpenAI's base URL
- The example app now correctly respects user preferences as intended

## Testing

- ✅ TypeScript compilation passes without errors
- ✅ Vite build completes successfully
- ✅ No breaking changes to the API or component interface

## Files Changed

- `example/src/components/ConversationManager.tsx`: Updated agent configuration to use user settings

This ensures the example application works as expected with user-configured settings rather than hardcoded values.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/597f473546ff4131ad6ec0344fc45ae8)