### PR TITLE
Add alpha software warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # OpenHands Agent Server TypeScript Client
 
+> ⚠️ **ALPHA SOFTWARE WARNING** ⚠️
+> 
+> This TypeScript SDK is currently in **alpha** and is **not stable**. The API may change significantly between versions without notice. This software is intended for early testing and development purposes only.
+> 
+> - Breaking changes may occur in any release
+> - Features may be incomplete or contain bugs
+> - Documentation may be outdated or incomplete
+> - Not recommended for production use
+> 
+> Please use with caution and expect frequent updates.
+
 A TypeScript client library for the OpenHands Agent Server API that mirrors the structure and functionality of the Python SDK.
 
 ## Features


### PR DESCRIPTION
## Summary

This PR adds a prominent alpha software warning to the top of the README to clearly communicate that this TypeScript SDK is currently in alpha and not stable.

## Changes

- Added a visually prominent warning section at the top of the README
- Included specific warnings about:
  - Potential breaking changes in any release
  - Incomplete features and possible bugs
  - Outdated or incomplete documentation
  - Not recommended for production use
- Used clear formatting with warning emojis and blockquotes for visibility

## Motivation

Since this is an alpha version of the TypeScript SDK, it's important to set proper expectations for users about the stability and maturity of the software. This warning helps prevent users from using it in production environments where stability is critical.

## Testing

- [x] Verified the warning displays correctly in the README
- [x] Confirmed the formatting renders properly in markdown

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e80afbe454134d189d8bafc69ba3b008)