### PR TITLE
Add GitHub Packages publishing workflow

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -1,23 +1,29 @@
-name: Release
+name: Publish to GitHub Packages
 
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (without v prefix)'
+        required: true
+        type: string
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 jobs:
-  release:
+  publish:
     runs-on: ubuntu-latest
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       
-    - name: Setup Node.js for GitHub Packages
+    - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 20.x
@@ -34,9 +40,14 @@ jobs:
     - name: Build package
       run: npm run build
       
-    - name: Extract version from tag
+    - name: Extract version from tag or input
       id: version
-      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+        else
+          echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        fi
       
     - name: Update package version
       run: npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
@@ -46,7 +57,8 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-    - name: Create GitHub Release
+    - name: Create GitHub Release (for tag pushes only)
+      if: github.event_name == 'push'
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ github.ref_name }}
@@ -57,20 +69,18 @@ jobs:
         body: |
           ## Installation from GitHub Packages
           
-          ### Option 1: Configure .npmrc (Recommended)
-          Add to your `.npmrc` file:
+          ```bash
+          npm install @openhands/typescript-client@${{ steps.version.outputs.VERSION }} --registry=https://npm.pkg.github.com
+          ```
+          
+          Or add to your `.npmrc`:
           ```
           @openhands:registry=https://npm.pkg.github.com
           ```
           
-          Then install:
+          Then install normally:
           ```bash
           npm install @openhands/typescript-client@${{ steps.version.outputs.VERSION }}
-          ```
-          
-          ### Option 2: Direct install with registry flag
-          ```bash
-          npm install @openhands/typescript-client@${{ steps.version.outputs.VERSION }} --registry=https://npm.pkg.github.com
           ```
           
           ## Usage
@@ -82,4 +92,6 @@ jobs:
             baseUrl: 'http://localhost:8000',
             apiKey: 'your-api-key'
           });
+          
+          await conversation.start();
           ```

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@openhands:registry=https://npm.pkg.github.com

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,105 @@
+# Publishing Guide
+
+This document explains how to publish the OpenHands TypeScript Client to GitHub Packages.
+
+## Overview
+
+The package is published exclusively to **GitHub Packages** for GitHub-native integration.
+
+## Automated Publishing (Recommended)
+
+### Prerequisites
+
+- **GitHub Token**: Automatically provided by GitHub Actions as `GITHUB_TOKEN`
+
+### Publishing Process
+
+1. **Create and push a version tag**:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+2. **The GitHub Action will automatically**:
+   - Run tests
+   - Build the package
+   - Update package.json version
+   - Publish to GitHub Packages
+   - Create a GitHub release with installation instructions
+
+## Manual Publishing
+
+### Setup
+
+1. **Configure npm for GitHub Packages**:
+   ```bash
+   npm login --registry=https://npm.pkg.github.com
+   # Username: your-github-username
+   # Password: your-github-token
+   ```
+
+### Publishing Steps
+
+1. **Update version**:
+   ```bash
+   npm version patch  # or minor, major
+   ```
+
+2. **Build the package**:
+   ```bash
+   npm run build
+   ```
+
+3. **Run tests**:
+   ```bash
+   npm test
+   ```
+
+4. **Publish to GitHub Packages**:
+   ```bash
+   npm publish --registry=https://npm.pkg.github.com --access public
+   ```
+
+## Installation Instructions for Users
+
+### From GitHub Packages
+
+#### Option 1: Configure .npmrc (Recommended)
+Add to your `.npmrc` file:
+```
+@openhands:registry=https://npm.pkg.github.com
+```
+
+Then install:
+```bash
+npm install @openhands/typescript-client
+```
+
+#### Option 2: Direct install with registry flag
+```bash
+npm install @openhands/typescript-client --registry=https://npm.pkg.github.com
+```
+
+## Troubleshooting
+
+### Authentication Issues
+
+- **GitHub Packages**: Ensure the `GITHUB_TOKEN` has `packages:write` permission
+
+### Version Conflicts
+
+If you encounter version conflicts, ensure:
+- The version in `package.json` matches the git tag
+- The version doesn't already exist in the registry
+
+### Build Failures
+
+Common issues:
+- TypeScript compilation errors: Fix in source code
+- Test failures: Ensure all tests pass before publishing
+- Missing dependencies: Run `npm ci` to install exact versions
+
+## Workflow Files
+
+- `.github/workflows/release.yml`: Main release workflow (GitHub Packages)
+- `.github/workflows/publish-github-packages.yml`: GitHub Packages only workflow with manual trigger

--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@
 A TypeScript client library for the OpenHands Agent Server API. Mirrors the structure and functionality of the Python [OpenHands Software Agent SDK](https://github.com/OpenHands/software-agent-sdk),
 but only supports remote conversations.
 
+## Installation
+
+This package is published to GitHub Packages. You have two installation options:
+
+### Option 1: Configure .npmrc (Recommended)
+Add this to your `.npmrc` file:
+```
+@openhands:registry=https://npm.pkg.github.com
+```
+
+Then install normally:
+```bash
+npm install @openhands/typescript-client
+```
+
+### Option 2: Direct install with registry flag
+```bash
+npm install @openhands/typescript-client --registry=https://npm.pkg.github.com
+```
+
 ## Quick Start
 
 ### Start an AgentServer
@@ -29,7 +49,7 @@ docker run -p 8000:8000 -p 8001:8001 \
 ### Creating a Conversation
 
 ```typescript
-import { Conversation, Agent, Workspace } from '@openhands/agent-server-typescript-client';
+import { Conversation, Agent, Workspace } from '@openhands/typescript-client';
 
 const agent = new Agent({
   llm: {
@@ -242,7 +262,7 @@ The library includes comprehensive TypeScript type definitions:
 The client includes proper error handling with custom error types:
 
 ```typescript
-import { HttpError } from '@openhands/agent-server-typescript-client';
+import { HttpError } from '@openhands/typescript-client';
 
 try {
   await conversation.sendMessage('Hello');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openhands/agent-server-typescript-client",
+  "name": "@openhands/typescript-client",
   "version": "0.1.0",
   "description": "TypeScript client for OpenHands Agent Server",
   "main": "dist/index.js",
@@ -50,6 +50,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/All-Hands-AI/agent-server-typescript-client.git"
+    "url": "https://github.com/OpenHands/typescript-client.git"
   }
 }


### PR DESCRIPTION
## Summary

This PR adds GitHub Actions workflow to publish the TypeScript client as a package to GitHub Packages (the most GitHub-native approach), removes npm publishing, and updates the package name to `@openhands/typescript-client`.

## Changes Made

### 🔧 Package Configuration
- **Updated package name** from `@openhands/agent-server-typescript-client` to `@openhands/typescript-client`
- **Removed npm publishing** - now exclusively uses GitHub Packages
- **Added `.npmrc`** configuration for GitHub Packages scope

### 🚀 GitHub Actions Workflows
- **Updated `.github/workflows/release.yml`** - Main workflow that publishes to GitHub Packages on tag push
- **Added `.github/workflows/publish-github-packages.yml`** - Alternative workflow with manual trigger option
- **Modern GitHub Actions** - Uses latest action versions, no deprecated actions
- **Automatic versioning** from git tags
- **Comprehensive testing** before publishing

### 📚 Documentation Updates
- **Updated `README.md`** with GitHub Packages installation instructions
- **Updated `PUBLISHING.md`** with GitHub Packages only publishing guide
- **Updated all import examples** to use new package name

## How to Publish

The **easiest and most GitHub-native way** is to simply push a version tag:

```bash
git tag v1.0.0
git push origin v1.0.0
```

This automatically:
- ✅ Runs tests
- ✅ Builds the package  
- ✅ Publishes to GitHub Packages
- ✅ Creates a GitHub release with installation instructions

## How Users Install

### Option 1: Configure .npmrc (Recommended)
```bash
echo "@openhands:registry=https://npm.pkg.github.com" >> .npmrc
npm install @openhands/typescript-client
```

### Option 2: Direct install with registry flag
```bash
npm install @openhands/typescript-client --registry=https://npm.pkg.github.com
```

## Testing

- ✅ Build passes: `npm run build`
- ✅ Tests pass: `npm test`
- ✅ Package name updated throughout codebase
- ✅ Documentation updated with new installation instructions

## Benefits

- **Most GitHub-native approach** - Uses GitHub Packages exclusively
- **Simplified workflow** - No need for npm tokens or dual publishing
- **Automatic GitHub integration** - Leverages built-in GitHub token
- **Cleaner package name** - Shorter and more intuitive
- **Complete automation** - Tag-based publishing with zero manual steps

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/88ea8fb0d7e54157b1587b5a4f478355)