### PR TITLE
Add setTitle() and persist title in generateTitle()

### DIFF
--- a/src/__tests__/event-types.test.ts
+++ b/src/__tests__/event-types.test.ts
@@ -224,7 +224,10 @@ describe('Event Type Guards', () => {
         timestamp: new Date().toISOString(),
         source: 'user',
         action_id: 'action_1',
-        reason: 'Too risky',
+        tool_name: 'execute_command',
+        tool_call_id: 'tool_call_1',
+        rejection_reason: 'Too risky',
+        rejection_source: 'user',
       };
 
       expect(isObservationLike(obs)).toBe(true);
@@ -328,11 +331,17 @@ describe('Event Structure', () => {
         timestamp: new Date().toISOString(),
         source: 'user',
         action_id: 'action_789',
-        reason: 'This action is too risky',
+        tool_name: 'execute_command',
+        tool_call_id: 'tool_call_789',
+        rejection_reason: 'This action is too risky',
+        rejection_source: 'user',
       };
 
       expect(event.action_id).toBe('action_789');
-      expect(event.reason).toBe('This action is too risky');
+      expect(event.tool_name).toBe('execute_command');
+      expect(event.tool_call_id).toBe('tool_call_789');
+      expect(event.rejection_reason).toBe('This action is too risky');
+      expect(event.rejection_source).toBe('user');
     });
   });
 });

--- a/src/client/http-client.ts
+++ b/src/client/http-client.ts
@@ -178,6 +178,14 @@ export class HttpClient {
     return this.request<T>({ method: 'PUT', url, data, ...options });
   }
 
+  async patch<T = any>(
+    url: string,
+    data?: any,
+    options?: Omit<RequestOptions, 'method' | 'url' | 'data'>
+  ): Promise<HttpResponse<T>> {
+    return this.request<T>({ method: 'PATCH', url, data, ...options });
+  }
+
   async delete<T = any>(
     url: string,
     options?: Omit<RequestOptions, 'method' | 'url'>

--- a/src/client/http-client.ts
+++ b/src/client/http-client.ts
@@ -49,7 +49,11 @@ export class HttpClient {
   }
 
   async request<T = any>(options: RequestOptions): Promise<HttpResponse<T>> {
-    const url = new URL(options.url, this.baseUrl);
+    // Strip leading slash so the path is resolved relative to the full baseUrl
+    // (including any path prefix), not just the origin. This allows serverUrl
+    // values like "https://example.com/apps/assistant/api" to work correctly.
+    const relativePath = options.url.startsWith('/') ? options.url.slice(1) : options.url;
+    const url = new URL(relativePath, this.baseUrl + '/');
 
     // Add query parameters
     if (options.params) {

--- a/src/conversation/base.ts
+++ b/src/conversation/base.ts
@@ -141,6 +141,13 @@ export interface IConversation {
   generateTitle(maxLength?: number, llm?: LLM): Promise<string>;
 
   /**
+   * Set the title of the conversation.
+   *
+   * @param title - The title to set
+   */
+  setTitle(title: string): Promise<void>;
+
+  /**
    * Update secrets available to the agent.
    *
    * @param secrets - Record of secret name to value mappings

--- a/src/conversation/conversation-manager.ts
+++ b/src/conversation/conversation-manager.ts
@@ -9,6 +9,7 @@ import {
   ConversationInfo,
   ConversationSearchRequest,
   ConversationSearchResponse,
+  UpdateConversationRequest,
 } from '../models/conversation';
 import { AgentBase, ConversationID, Success } from '../types/base';
 
@@ -139,6 +140,20 @@ export class ConversationManager {
    */
   async deleteConversation(conversationId: ConversationID): Promise<void> {
     await this.client.delete<Success>(`/api/conversations/${conversationId}`);
+  }
+
+  /**
+   * Update conversation metadata (e.g. title)
+   */
+  async updateConversation(
+    conversationId: ConversationID,
+    update: UpdateConversationRequest
+  ): Promise<ConversationInfo> {
+    const response = await this.client.patch<ConversationInfo>(
+      `/api/conversations/${conversationId}`,
+      update
+    );
+    return response.data;
   }
 
   /**

--- a/src/conversation/local-conversation.ts
+++ b/src/conversation/local-conversation.ts
@@ -309,6 +309,7 @@ export class LocalConversation implements IConversation {
 
   private _conversationId?: string;
   private _state?: LocalConversationState;
+  private _title?: string;
   private callback?: ConversationCallbackType;
   private tokenCallback?: ConversationTokenCallback;
   private persistenceDir?: string;
@@ -708,6 +709,10 @@ export class LocalConversation implements IConversation {
     }
   }
 
+  async setTitle(title: string): Promise<void> {
+    this._title = title;
+  }
+
   /**
    * Generate a title for the conversation using the LLM.
    */
@@ -788,7 +793,10 @@ Provide a direct answer without using any tools.`;
         timestamp: new Date().toISOString(),
         source: 'user',
         action_id: actionId,
-        reason,
+        tool_name: action.tool_name ?? '',
+        tool_call_id: action.tool_call_id ?? '',
+        rejection_reason: reason,
+        rejection_source: 'user',
       };
 
       this.emitTypedEvent(rejectEvent);

--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -27,6 +27,7 @@ import {
   CreateConversationRequest,
   GenerateTitleRequest,
   GenerateTitleResponse,
+  UpdateConversationRequest,
   UpdateSecretsRequest,
   AskAgentRequest,
   AskAgentResponse,
@@ -180,6 +181,11 @@ export class RemoteConversation implements IConversation {
     await this.client.post(`/api/conversations/${this.id}/events/respond_to_confirmation`, request);
   }
 
+  async setTitle(title: string): Promise<void> {
+    const request: UpdateConversationRequest = { title };
+    await this.client.patch(`/api/conversations/${this.id}`, request);
+  }
+
   async generateTitle(maxLength: number = 50, llm?: LLM): Promise<string> {
     const request: GenerateTitleRequest = { max_length: maxLength };
     if (llm) {
@@ -190,7 +196,9 @@ export class RemoteConversation implements IConversation {
       `/api/conversations/${this.id}/generate_title`,
       request
     );
-    return response.data.title;
+    const title = response.data.title;
+    await this.setTitle(title);
+    return title;
   }
 
   /**

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -153,8 +153,14 @@ export interface UserRejectObservation extends BaseEvent {
   kind: 'UserRejectObservation';
   /** ID of the rejected action */
   action_id: string;
+  /** Name of the tool that was rejected */
+  tool_name: string;
+  /** ID of the tool call that was rejected */
+  tool_call_id: string;
   /** Reason for rejection */
-  reason: string;
+  rejection_reason: string;
+  /** Source of the rejection */
+  rejection_source: 'user' | 'system';
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,7 @@ export type {
   CreateConversationRequest,
   GenerateTitleRequest,
   GenerateTitleResponse,
+  UpdateConversationRequest,
   UpdateSecretsRequest,
   StaticSecret,
   LookupSecret,

--- a/src/models/conversation.ts
+++ b/src/models/conversation.ts
@@ -73,6 +73,10 @@ export interface GenerateTitleResponse {
   title: string;
 }
 
+export interface UpdateConversationRequest {
+  title: string;
+}
+
 export interface StaticSecret {
   kind: 'StaticSecret';
   value: string;


### PR DESCRIPTION
- HttpClient: add patch() method
- models/conversation: add UpdateConversationRequest interface
- IConversation: add setTitle(title) to base interface
- RemoteConversation: implement setTitle() via PATCH /api/conversations/{id}, and call it automatically at the end of generateTitle() so the title is always persisted after generation
- LocalConversation: implement setTitle() storing on _title field; also fix pre-existing bug where UserRejectObservation was missing required fields (tool_name, tool_call_id, rejection_source)