### PR TITLE
Remove console.log that leaks HTTP request bodies

### DIFF
--- a/src/client/http-client.ts
+++ b/src/client/http-client.ts
@@ -87,9 +87,7 @@ export class HttpClient {
         delete headers['Content-Type'];
         requestInit.body = options.data;
       } else {
-        const bodyData = JSON.stringify(options.data);
-        console.log('HTTP Request Body:', bodyData);
-        requestInit.body = bodyData;
+        requestInit.body = JSON.stringify(options.data);
       }
     }
 


### PR DESCRIPTION
## Problem

`console.log("HTTP Request Body:", bodyData)` on line 91 of `src/client/http-client.ts` fires on **every non-GET HTTP request**, dumping the full JSON request body to the console.

This leaks:
- API keys and auth tokens
- Secret values
- User messages and content
- Agent configurations

In browsers this goes to DevTools; in Node.js it goes to stdout which may be captured by logging/observability infrastructure.

## Fix

Remove the debug log line. The `bodyData` intermediate variable is also eliminated since it served no other purpose.

---
*This PR was created by an AI assistant (OpenHands) to address issue #1 from the code audit (REVIEW.md).*