### PR TITLE
Consolidate duplicate type definitions

### DIFF
--- a/src/conversation/secret-registry.ts
+++ b/src/conversation/secret-registry.ts
@@ -6,11 +6,10 @@
  * This mirrors the Python SDK's SecretRegistry class.
  */
 
-/**
- * A secret value can be a static string or a function that returns a string.
- * Functions are evaluated lazily when the secret is needed.
- */
-export type SecretValue = string | (() => string);
+import { SecretValue } from '../types/base';
+
+// Re-export so existing consumers of this module still find the type
+export type { SecretValue } from '../types/base';
 
 /**
  * Secret source types

--- a/src/security/confirmation-policy.ts
+++ b/src/security/confirmation-policy.ts
@@ -13,6 +13,22 @@ import { ActionEvent } from '../events/types';
 export type RiskLevel = 'low' | 'medium' | 'high' | 'unknown';
 
 /**
+ * Convert a risk level to a numeric value for comparison.
+ */
+export function riskLevelToNumeric(level: RiskLevel): number {
+  switch (level) {
+    case 'low':
+      return 1;
+    case 'medium':
+      return 2;
+    case 'high':
+      return 3;
+    case 'unknown':
+      return 2; // Treat unknown as medium
+  }
+}
+
+/**
  * Result of a security analysis
  */
 export interface SecurityAnalysisResult {
@@ -80,22 +96,9 @@ export class RiskBasedConfirm implements ConfirmationPolicy {
     this.threshold = threshold;
   }
 
-  private riskValue(level: RiskLevel): number {
-    switch (level) {
-      case 'low':
-        return 1;
-      case 'medium':
-        return 2;
-      case 'high':
-        return 3;
-      case 'unknown':
-        return 2; // Treat unknown as medium
-    }
-  }
-
   requiresConfirmation(_action: ActionEvent, riskLevel?: RiskLevel): boolean {
     const level = riskLevel || 'unknown';
-    return this.riskValue(level) >= this.riskValue(this.threshold);
+    return riskLevelToNumeric(level) >= riskLevelToNumeric(this.threshold);
   }
 }
 

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -4,6 +4,7 @@
 
 export {
   RiskLevel,
+  riskLevelToNumeric,
   SecurityAnalysisResult,
   ConfirmationPolicy,
   NeverConfirm,

--- a/src/security/security-analyzer.ts
+++ b/src/security/security-analyzer.ts
@@ -6,7 +6,7 @@
  */
 
 import { ActionEvent } from '../events/types';
-import { RiskLevel, SecurityAnalysisResult } from './confirmation-policy';
+import { RiskLevel, SecurityAnalysisResult, riskLevelToNumeric } from './confirmation-policy';
 
 /**
  * Base interface for security analyzers.
@@ -228,7 +228,7 @@ export class CompositeAnalyzer implements SecurityAnalyzer {
     const explanations: string[] = [];
 
     for (const result of results) {
-      if (this.riskValue(result.riskLevel) > this.riskValue(highestRisk)) {
+      if (riskLevelToNumeric(result.riskLevel) > riskLevelToNumeric(highestRisk)) {
         highestRisk = result.riskLevel;
       }
       if (result.concerns) {
@@ -247,18 +247,6 @@ export class CompositeAnalyzer implements SecurityAnalyzer {
     };
   }
 
-  private riskValue(level: RiskLevel): number {
-    switch (level) {
-      case 'low':
-        return 1;
-      case 'medium':
-        return 2;
-      case 'high':
-        return 3;
-      case 'unknown':
-        return 2;
-    }
-  }
 }
 
 /**

--- a/src/security/security-analyzer.ts
+++ b/src/security/security-analyzer.ts
@@ -246,7 +246,6 @@ export class CompositeAnalyzer implements SecurityAnalyzer {
       concerns: allConcerns.length > 0 ? allConcerns : undefined,
     };
   }
-
 }
 
 /**


### PR DESCRIPTION
## Problem

Multiple types are defined in more than one place:

| Type | Location 1 | Location 2 |
|------|-----------|------------|
| `SecretValue` | `types/base.ts:158` | `secret-registry.ts:13` |
| `riskValue()` | `confirmation-policy.ts:83` | `security-analyzer.ts:250` |

## Fix

- **`SecretValue`**: Delete the duplicate in `secret-registry.ts`, import from `types/base.ts`. Re-export for backward compatibility.
- **`riskValue()`**: Extract the identical switch statement into a shared `riskLevelToNumeric()` function in `confirmation-policy.ts`. Both `RiskBasedConfirm` and `CompositeAnalyzer` now call the shared function.

All tests pass, type checking passes.

---
*This PR was created by an AI assistant (OpenHands) to address issue #4 from the code audit (REVIEW.md).*