### PR TITLE
Use crypto.randomUUID() and remove unused uuid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@openrouter/sdk": "^0.8.0",
-        "uuid": "^13.0.0",
         "ws": "^8.19.0"
       },
       "devDependencies": {
@@ -18,7 +17,6 @@
         "@eslint/js": "^10.0.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.2.0",
-        "@types/uuid": "^11.0.0",
         "@types/ws": "^8.5.8",
         "@typescript-eslint/eslint-plugin": "^8.53.1",
         "@typescript-eslint/parser": "^8.53.1",
@@ -2708,17 +2706,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -6960,19 +6947,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "license": "MIT",
   "dependencies": {
     "@openrouter/sdk": "^0.8.0",
-    "uuid": "^13.0.0",
     "ws": "^8.19.0"
   },
   "devDependencies": {
@@ -44,7 +43,6 @@
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.2.0",
-    "@types/uuid": "^11.0.0",
     "@types/ws": "^8.5.8",
     "@typescript-eslint/eslint-plugin": "^8.53.1",
     "@typescript-eslint/parser": "^8.53.1",

--- a/src/conversation/local-conversation.ts
+++ b/src/conversation/local-conversation.ts
@@ -948,10 +948,6 @@ Provide a direct answer without using any tools.`;
    * Generate a unique conversation ID.
    */
   private generateConversationId(): string {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-      const r = (Math.random() * 16) | 0;
-      const v = c === 'x' ? r : (r & 0x3) | 0x8;
-      return v.toString(16);
-    });
+    return crypto.randomUUID();
   }
 }

--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -5,7 +5,6 @@
  * agent server. It mirrors the Python SDK's RemoteConversation class.
  */
 
-// import { v4 as uuidv4 } from 'uuid'; // Unused for now
 import { HttpClient } from '../client/http-client';
 import { WebSocketCallbackClient } from '../events/websocket-client';
 import { RemoteState } from './remote-state';

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -421,7 +421,7 @@ export function isHookExecutionEvent(event: BaseEvent): event is HookExecutionEv
  * Generate a unique event ID
  */
 export function generateEventId(): EventID {
-  return `evt_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  return `evt_${Date.now()}_${crypto.randomUUID().substring(0, 8)}`;
 }
 
 /**


### PR DESCRIPTION
## Problem

- `uuid` package (`^13.0.0`) is listed as a runtime dependency but never used
- `generateEventId()` uses `Math.random()` (not cryptographically random, can collide) and deprecated `substr()`
- `generateConversationId()` has a hand-rolled UUID implementation using `Math.random()`
- `remote-conversation.ts` has a commented-out uuid import

## Fix

- Replace both ID generators with `crypto.randomUUID()` (Web Crypto API — available in all modern browsers and Node 19+)
- Remove `uuid` and `@types/uuid` from dependencies
- Remove the commented-out import

---
*This PR was created by an AI assistant (OpenHands) to address issue #7 from the code audit (REVIEW.md).*