### PR TITLE
Extract shared buildRequestParams in OpenRouterLLM

### DIFF
--- a/src/llm/openrouter-llm.ts
+++ b/src/llm/openrouter-llm.ts
@@ -167,18 +167,19 @@ export class OpenRouterLLM implements ILLM {
     }));
   }
 
-  async chatCompletion(options: ChatCompletionOptions): Promise<ChatCompletionResponse> {
-    const model = options.model || this.defaultModel;
-    const messages = this.convertMessages(options.messages);
-
-    // Build the request - using 'any' to handle SDK type complexity
+  /**
+   * Build the common request parameters shared by chatCompletion and chatCompletionStream.
+   */
+  private buildRequestParams(
+    options: ChatCompletionOptions | Omit<ChatCompletionOptions, 'stream'>,
+    stream: boolean
+  ): Record<string, unknown> {
     const requestParams: Record<string, unknown> = {
-      model,
-      messages,
-      stream: false,
+      model: options.model || this.defaultModel,
+      messages: this.convertMessages(options.messages),
+      stream,
     };
 
-    // Add optional parameters
     if (options.temperature !== undefined) {
       requestParams.temperature = options.temperature;
     } else if (this.defaultTemperature !== undefined) {
@@ -202,6 +203,13 @@ export class OpenRouterLLM implements ILLM {
     if (options.stop) {
       requestParams.stop = options.stop;
     }
+
+    return requestParams;
+  }
+
+  async chatCompletion(options: ChatCompletionOptions): Promise<ChatCompletionResponse> {
+    const model = options.model || this.defaultModel;
+    const requestParams = this.buildRequestParams(options, false);
 
     // Cast to expected type - SDK handles validation
     const response = (await this.client.chat.send(
@@ -239,41 +247,8 @@ export class OpenRouterLLM implements ILLM {
     options: Omit<ChatCompletionOptions, 'stream'>
   ): AsyncIterable<ChatCompletionChunk> {
     const model = options.model || this.defaultModel;
-    const messages = this.convertMessages(options.messages);
+    const requestParams = this.buildRequestParams(options, true);
 
-    // Build the request - using 'any' to handle SDK type complexity
-    const requestParams: Record<string, unknown> = {
-      model,
-      messages,
-      stream: true,
-    };
-
-    // Add optional parameters
-    if (options.temperature !== undefined) {
-      requestParams.temperature = options.temperature;
-    } else if (this.defaultTemperature !== undefined) {
-      requestParams.temperature = this.defaultTemperature;
-    }
-
-    if (options.maxTokens !== undefined) {
-      requestParams.maxTokens = options.maxTokens;
-    } else if (this.defaultMaxTokens !== undefined) {
-      requestParams.maxTokens = this.defaultMaxTokens;
-    }
-
-    if (options.tools && options.tools.length > 0) {
-      requestParams.tools = this.convertTools(options.tools);
-    }
-
-    if (options.toolChoice) {
-      requestParams.toolChoice = options.toolChoice;
-    }
-
-    if (options.stop) {
-      requestParams.stop = options.stop;
-    }
-
-    // Cast to expected type - SDK handles validation
     const stream = await this.client.chat.send(
       requestParams as Parameters<typeof this.client.chat.send>[0]
     );


### PR DESCRIPTION
## Problem

`chatCompletion()` and `chatCompletionStream()` in `openrouter-llm.ts` had ~20 identical lines constructing request parameters (model, messages, temperature, maxTokens, tools, toolChoice, stop). Adding a new parameter meant updating two places.

## Fix

Extract a private `buildRequestParams(options, stream)` helper. Both methods now call it with their respective `stream` flag.

---
*This PR was created by an AI assistant (OpenHands) to address issue #8 from the code audit (REVIEW.md).*