### PR TITLE
Add conversation tags support

### DIFF
--- a/src/client/http-client.ts
+++ b/src/client/http-client.ts
@@ -59,7 +59,11 @@ export class HttpClient {
     if (options.params) {
       Object.entries(options.params).forEach(([key, value]) => {
         if (value !== undefined && value !== null) {
-          url.searchParams.append(key, String(value));
+          if (Array.isArray(value)) {
+            value.forEach((v: unknown) => url.searchParams.append(key, String(v)));
+          } else {
+            url.searchParams.append(key, String(value));
+          }
         }
       });
     }

--- a/src/conversation/conversation-manager.ts
+++ b/src/conversation/conversation-manager.ts
@@ -52,7 +52,7 @@ export class ConversationManager {
   /**
    * Get all conversations (convenience method)
    */
-  async getAllConversations(): Promise<ConversationInfo[]> {
+  async getAllConversations(options?: { tag?: string[] }): Promise<ConversationInfo[]> {
     const conversations: ConversationInfo[] = [];
     let nextPageId: string | undefined;
 
@@ -60,6 +60,7 @@ export class ConversationManager {
       const response = await this.searchConversations({
         page_id: nextPageId,
         limit: 100,
+        ...(options?.tag ? { tag: options.tag } : {}),
       });
 
       conversations.push(...response.items);

--- a/src/models/conversation.ts
+++ b/src/models/conversation.ts
@@ -79,7 +79,8 @@ export interface GenerateTitleResponse {
 }
 
 export interface UpdateConversationRequest {
-  title: string;
+  title?: string;
+  tags?: Record<string, string>;
 }
 
 export interface StaticSecret {
@@ -106,6 +107,7 @@ export interface ConversationSearchRequest {
   limit?: number;
   status?: ConversationExecutionStatus;
   sort_order?: string;
+  tag?: string[];
 }
 
 export interface AskAgentRequest {


### PR DESCRIPTION
## Summary

Adds support for conversation tags across the TypeScript client.

### Changes

- **HTTP client**: Handle array values in query parameters by appending each element separately
- **ConversationManager**: `getAllConversations` now accepts an optional `{ tag: string[] }` filter
- **Models**:
  - `UpdateConversationRequest`: `title` is now optional; added `tags` field (`Record<string, string>`)
  - `ConversationSearchRequest`: Added `tag` field (`string[]`)

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._