### PR TITLE
fix: throw on network errors in RemoteWorkspace instead of returning fake results

### DIFF
--- a/src/__tests__/integration/workspace.integration.test.ts
+++ b/src/__tests__/integration/workspace.integration.test.ts
@@ -5,7 +5,7 @@
  * running in a Docker container with a mounted workspace volume.
  */
 
-import { RemoteWorkspace, Workspace } from '../../index';
+import { HttpError, RemoteWorkspace, Workspace } from '../../index';
 import { getTestConfig, skipIfNoConfig } from './test-config';
 import {
   readWorkspaceFile,
@@ -325,16 +325,13 @@ describe('RemoteWorkspace Integration Tests', () => {
     );
 
     it(
-      'should fail gracefully for non-existent file',
+      'should throw HttpError for non-existent file',
       async () => {
         if (SKIP_TESTS) return;
 
-        const result = await workspace.fileDownload(
-          `${config.agentWorkspaceDir}/non-existent-file-${Date.now()}.txt`
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toBeDefined();
+        await expect(
+          workspace.fileDownload(`${config.agentWorkspaceDir}/non-existent-file-${Date.now()}.txt`)
+        ).rejects.toBeInstanceOf(HttpError);
       },
       config?.testTimeout || 30000
     );

--- a/src/workspace/remote-workspace.ts
+++ b/src/workspace/remote-workspace.ts
@@ -137,12 +137,9 @@ export class RemoteWorkspace implements IWorkspace {
   }
 
   async fileDownload(sourcePath: string): Promise<FileDownloadResult> {
-    const response = await this.client.get(
-      `/api/file/download/${encodeURIComponent(sourcePath)}`,
-      {
-        timeout: 60000,
-      }
-    );
+    const response = await this.client.get(`/api/file/download/${encodeURIComponent(sourcePath)}`, {
+      timeout: 60000,
+    });
 
     let content: string | Blob;
     let fileSize: number;

--- a/src/workspace/remote-workspace.ts
+++ b/src/workspace/remote-workspace.ts
@@ -66,42 +66,32 @@ export class RemoteWorkspace implements IWorkspace {
     cwd?: string,
     timeout: number = 30.0
   ): Promise<CommandResult> {
-    console.debug(`Executing remote command: ${command}`);
+    const payload: Record<string, unknown> = {
+      command,
+      timeout: Math.floor(timeout),
+    };
 
-    try {
-      const payload: any = {
-        command,
-        timeout: Math.floor(timeout),
-      };
-
-      if (cwd) {
-        payload.cwd = cwd;
-      }
-
-      // The API waits for the command to complete and returns the result directly
-      const response = await this.client.post('/api/bash/execute_bash_command', payload, {
-        timeout: (timeout + 10) * 1000, // Add buffer for network latency
-      });
-
-      const bashOutput = response.data;
-
-      return {
-        command,
-        exit_code: bashOutput.exit_code ?? 0,
-        stdout: bashOutput.stdout || '',
-        stderr: bashOutput.stderr || '',
-        timeout_occurred: false,
-      };
-    } catch (error) {
-      console.error(`Remote command execution failed: ${error}`);
-      return {
-        command,
-        exit_code: -1,
-        stdout: '',
-        stderr: `Remote execution error: ${error instanceof Error ? error.message : String(error)}`,
-        timeout_occurred: false,
-      };
+    if (cwd) {
+      payload.cwd = cwd;
     }
+
+    // The API waits for the command to complete and returns the result directly.
+    // Network/HTTP errors are intentionally NOT caught here — callers should
+    // handle HttpError (infrastructure failure) separately from CommandResult
+    // (actual command execution result).
+    const response = await this.client.post('/api/bash/execute_bash_command', payload, {
+      timeout: (timeout + 10) * 1000, // Add buffer for network latency
+    });
+
+    const bashOutput = response.data;
+
+    return {
+      command,
+      exit_code: bashOutput.exit_code ?? 0,
+      stdout: bashOutput.stdout || '',
+      stderr: bashOutput.stderr || '',
+      timeout_occurred: false,
+    };
   }
 
   async fileUpload(
@@ -109,104 +99,75 @@ export class RemoteWorkspace implements IWorkspace {
     destinationPath: string,
     fileName?: string
   ): Promise<FileOperationResult> {
-    console.debug(`Remote file upload to: ${destinationPath}`);
+    const formData = new FormData();
 
-    try {
-      // Create FormData for file upload
-      const formData = new FormData();
+    let blob: Blob;
+    let finalFileName: string;
 
-      let blob: Blob;
-      let finalFileName: string;
-
-      if (content instanceof File) {
-        blob = content;
-        finalFileName = fileName || content.name;
-      } else if (content instanceof Blob) {
-        blob = content;
-        finalFileName = fileName || 'blob-file';
-      } else {
-        // String content
-        blob = new Blob([content], { type: 'text/plain' });
-        finalFileName = fileName || 'text-file.txt';
-      }
-
-      formData.append('file', blob, finalFileName);
-
-      // The API expects the path in the URL, not in the form data
-      const encodedPath = encodeURIComponent(destinationPath);
-      const response = await this.client.request({
-        method: 'POST',
-        url: `/api/file/upload/${encodedPath}`,
-        data: formData,
-        timeout: 60000,
-      });
-
-      const resultData = response.data;
-
-      return {
-        success: resultData.success ?? true,
-        source_path: finalFileName,
-        destination_path: destinationPath,
-        file_size: resultData.file_size,
-        error: resultData.error,
-      };
-    } catch (error) {
-      console.error(`Remote file upload failed: ${error}`);
-      return {
-        success: false,
-        source_path: fileName || 'unknown',
-        destination_path: destinationPath,
-        error: error instanceof Error ? error.message : String(error),
-      };
+    if (content instanceof File) {
+      blob = content;
+      finalFileName = fileName || content.name;
+    } else if (content instanceof Blob) {
+      blob = content;
+      finalFileName = fileName || 'blob-file';
+    } else {
+      blob = new Blob([content], { type: 'text/plain' });
+      finalFileName = fileName || 'text-file.txt';
     }
+
+    formData.append('file', blob, finalFileName);
+
+    const encodedPath = encodeURIComponent(destinationPath);
+    const response = await this.client.request({
+      method: 'POST',
+      url: `/api/file/upload/${encodedPath}`,
+      data: formData,
+      timeout: 60000,
+    });
+
+    const resultData = response.data;
+
+    return {
+      success: resultData.success ?? true,
+      source_path: finalFileName,
+      destination_path: destinationPath,
+      file_size: resultData.file_size,
+      error: resultData.error,
+    };
   }
 
   async fileDownload(sourcePath: string): Promise<FileDownloadResult> {
-    console.debug(`Remote file download: ${sourcePath}`);
-
-    try {
-      const response = await this.client.get(
-        `/api/file/download/${encodeURIComponent(sourcePath)}`,
-        {
-          timeout: 60000,
-        }
-      );
-
-      // Convert response data to appropriate format
-      let content: string | Blob;
-      let fileSize: number;
-
-      if (typeof response.data === 'string') {
-        content = response.data;
-        fileSize = new Blob([response.data]).size;
-      } else if (response.data instanceof ArrayBuffer) {
-        content = new Blob([response.data]);
-        fileSize = response.data.byteLength;
-      } else if (response.data instanceof Blob) {
-        content = response.data;
-        fileSize = response.data.size;
-      } else {
-        // For other data types, stringify and create blob
-        const stringData = JSON.stringify(response.data);
-        content = stringData;
-        fileSize = new Blob([stringData]).size;
+    const response = await this.client.get(
+      `/api/file/download/${encodeURIComponent(sourcePath)}`,
+      {
+        timeout: 60000,
       }
+    );
 
-      return {
-        success: true,
-        source_path: sourcePath,
-        content: content,
-        file_size: fileSize,
-      };
-    } catch (error) {
-      console.error(`Remote file download failed: ${error}`);
-      return {
-        success: false,
-        source_path: sourcePath,
-        content: '',
-        error: error instanceof Error ? error.message : String(error),
-      };
+    let content: string | Blob;
+    let fileSize: number;
+
+    if (typeof response.data === 'string') {
+      content = response.data;
+      fileSize = new Blob([response.data]).size;
+    } else if (response.data instanceof ArrayBuffer) {
+      content = new Blob([response.data]);
+      fileSize = response.data.byteLength;
+    } else if (response.data instanceof Blob) {
+      content = response.data;
+      fileSize = response.data.size;
+    } else {
+      const stringData = JSON.stringify(response.data);
+      content = stringData;
+      fileSize = new Blob([stringData]).size;
     }
+
+    return {
+      success: true,
+      source_path: sourcePath,
+      content: content,
+      file_size: fileSize,
+    };
   }
 
   async gitChanges(path: string): Promise<GitChange[]> {


### PR DESCRIPTION
## Summary

`executeCommand`, `fileUpload`, and `fileDownload` previously caught **all** errors (including network failures, HTTP errors, timeouts) and returned valid-looking result objects with error messages stuffed into `stderr`/`error` fields. This made it impossible for callers to distinguish infrastructure failures from actual command/file operation results.

For example, `executeCommand` returned `{ exit_code: -1, stderr: "Remote execution error: ..." }` on network failure — the agent would treat a server outage as if a command returned exit code -1.

## Changes

- `executeCommand`: Let `HttpError` propagate instead of catch-and-return fake `CommandResult`
- `fileUpload`: Let `HttpError` propagate instead of catch-and-return `{ success: false }`
- `fileDownload`: Let `HttpError` propagate instead of catch-and-return `{ success: false }`
- Removed `console.debug`/`console.error` calls from these methods
- Replaced `payload: any` with `payload: Record<string, unknown>` in `executeCommand`

Callers can now:
- Catch `HttpError` for infrastructure failures (network down, auth failure, timeout)
- Inspect `CommandResult.exit_code` / `FileOperationResult.success` for actual operation results

Note: `gitChanges` and `gitDiff` already threw on errors — this makes the behavior consistent across all methods.

Fixes #105

_This PR was created by an AI agent (OpenHands) on behalf of Robert Brennan._