### PR TITLE
fix: stop swallowing errors — propagate via onError callbacks

### DIFF
--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -6,7 +6,7 @@
  */
 
 import { HttpClient } from '../client/http-client';
-import { WebSocketCallbackClient } from '../events/websocket-client';
+import { WebSocketCallbackClient, ErrorCallbackType } from '../events/websocket-client';
 import { RemoteState } from './remote-state';
 import { RemoteWorkspace } from '../workspace/remote-workspace';
 import {
@@ -46,6 +46,11 @@ export interface RemoteConversationOptions extends BaseConversationOptions {
    * (PreToolUse, PostToolUse, UserPromptSubmit, Stop, etc.).
    */
   hookConfig?: HookConfig;
+  /**
+   * Optional error callback for non-fatal errors (WebSocket issues, state update failures).
+   * If not provided, these errors are silently ignored.
+   */
+  onError?: ErrorCallbackType;
 }
 
 /**
@@ -78,6 +83,7 @@ export class RemoteConversation implements IConversation {
   private client: HttpClient;
   private wsClient?: WebSocketCallbackClient;
   private callback?: ConversationCallbackType;
+  private onError?: ErrorCallbackType;
   private hookConfig?: HookConfig;
 
   constructor(
@@ -88,6 +94,7 @@ export class RemoteConversation implements IConversation {
     this.agent = agent;
     this.workspace = workspace;
     this.callback = options.callback;
+    this.onError = options.onError;
     this._conversationId = options.conversationId;
     this.hookConfig = options.hookConfig;
 
@@ -296,15 +303,25 @@ export class RemoteConversation implements IConversation {
       return;
     }
 
+    const reportError = (error: Error): void => {
+      if (this.onError) {
+        this.onError(error);
+      }
+    };
+
     // Create combined callback that handles both user callback and state updates
     const combinedCallback: ConversationCallbackType = (event) => {
       // Add event to the events list
       this.state.events.addEvent(event).catch((error) => {
-        console.error('Error adding event to events list:', error);
+        reportError(
+          error instanceof Error
+            ? error
+            : new Error(`Error adding event to events list: ${error}`)
+        );
       });
 
       // Update state if it's a state update event
-      const stateCallback = this.state.createStateUpdateCallback();
+      const stateCallback = this.state.createStateUpdateCallback(this.onError);
       stateCallback(event);
 
       // Call user callback if provided
@@ -318,6 +335,7 @@ export class RemoteConversation implements IConversation {
       conversationId: this.id,
       callback: combinedCallback,
       apiKey: this.workspace.apiKey,
+      onError: this.onError,
     });
 
     this.wsClient.start();

--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -314,9 +314,7 @@ export class RemoteConversation implements IConversation {
       // Add event to the events list
       this.state.events.addEvent(event).catch((error) => {
         reportError(
-          error instanceof Error
-            ? error
-            : new Error(`Error adding event to events list: ${error}`)
+          error instanceof Error ? error : new Error(`Error adding event to events list: ${error}`)
         );
       });
 

--- a/src/conversation/remote-state.ts
+++ b/src/conversation/remote-state.ts
@@ -92,11 +92,17 @@ export class RemoteState {
     });
   }
 
-  createStateUpdateCallback(): ConversationCallbackType {
+  createStateUpdateCallback(onError?: (error: Error) => void): ConversationCallbackType {
     return (event: Event) => {
       if (event.kind === 'ConversationStateUpdateEvent') {
         this.updateStateFromEvent(event as ConversationStateUpdateEvent).catch((error) => {
-          console.error('Error updating state from event:', error);
+          if (onError) {
+            onError(
+              error instanceof Error
+                ? error
+                : new Error(`Error updating state from event: ${error}`)
+            );
+          }
         });
       }
     };

--- a/src/conversation/secret-registry.ts
+++ b/src/conversation/secret-registry.ts
@@ -54,8 +54,7 @@ export class CallableSecretSource implements SecretSource {
   getValue(): string | null {
     try {
       return this.getter();
-    } catch (error) {
-      console.error('Error retrieving secret from callable:', error);
+    } catch {
       return null;
     }
   }
@@ -187,15 +186,10 @@ export class SecretRegistry {
       const source = this.secretSources.get(key);
       if (!source) continue;
 
-      try {
-        const value = source.getValue();
-        if (value) {
-          envVars[key] = value;
-          // Track successfully exported values for masking
-          this.exportedValues.set(key, value);
-        }
-      } catch (error) {
-        console.error(`Failed to retrieve secret for key '${key}':`, error);
+      const value = source.getValue();
+      if (value) {
+        envVars[key] = value;
+        this.exportedValues.set(key, value);
       }
     }
 

--- a/src/events/remote-events-list.ts
+++ b/src/events/remote-events-list.ts
@@ -102,10 +102,14 @@ export class RemoteEventsList {
     await this.addEvent(event);
   }
 
-  createDefaultCallback(): ConversationCallbackType {
+  createDefaultCallback(onError?: (error: Error) => void): ConversationCallbackType {
     return (event: Event) => {
       this.addEvent(event).catch((error) => {
-        console.error('Error adding event to cache:', error);
+        if (onError) {
+          onError(
+            error instanceof Error ? error : new Error(`Error adding event to cache: ${error}`)
+          );
+        }
       });
     };
   }

--- a/src/events/websocket-client.ts
+++ b/src/events/websocket-client.ts
@@ -23,11 +23,19 @@ if (typeof window !== 'undefined' && window.WebSocket) {
   }
 }
 
+/**
+ * Error callback type for reporting non-fatal errors.
+ * Library code calls this instead of console.error so callers can handle errors.
+ */
+export type ErrorCallbackType = (error: Error) => void;
+
 export interface WebSocketClientOptions {
   host: string;
   conversationId: string;
   callback: ConversationCallbackType;
   apiKey?: string;
+  /** Optional error callback. Called for non-fatal errors (parse failures, connection issues). */
+  onError?: ErrorCallbackType;
 }
 
 export class WebSocketCallbackClient {
@@ -35,6 +43,7 @@ export class WebSocketCallbackClient {
   private conversationId: string;
   private callback: ConversationCallbackType;
   private apiKey?: string;
+  private onError?: ErrorCallbackType;
   private ws?: any; // WebSocket instance (browser or Node.js)
   private reconnectDelay = 1000;
   private maxReconnectDelay = 30000;
@@ -47,6 +56,7 @@ export class WebSocketCallbackClient {
     this.conversationId = options.conversationId;
     this.callback = options.callback;
     this.apiKey = options.apiKey;
+    this.onError = options.onError;
   }
 
   start(): void {
@@ -94,7 +104,11 @@ export class WebSocketCallbackClient {
           const eventData: Event = JSON.parse(message);
           this.callback(eventData);
         } catch (error) {
-          console.error('Error processing WebSocket message:', error);
+          this.reportError(
+            new Error(
+              `Error processing WebSocket message: ${error instanceof Error ? error.message : String(error)}`
+            )
+          );
         }
       };
 
@@ -111,10 +125,23 @@ export class WebSocketCallbackClient {
         }
       };
     } catch (error) {
-      console.error('Failed to create WebSocket connection:', error);
+      this.reportError(
+        new Error(
+          `Failed to create WebSocket connection: ${error instanceof Error ? error.message : String(error)}`
+        )
+      );
       if (this.shouldReconnect) {
         this.scheduleReconnect();
       }
+    }
+  }
+
+  /**
+   * Report a non-fatal error via the onError callback if provided.
+   */
+  private reportError(error: Error): void {
+    if (this.onError) {
+      this.onError(error);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ export {
 
 // WebSocket client for real-time events
 export { WebSocketCallbackClient } from './events/websocket-client';
+export type { ErrorCallbackType } from './events/websocket-client';
 
 // HTTP client
 export { HttpClient, HttpError } from './client/http-client';


### PR DESCRIPTION
## Summary

Replace all `console.error` calls in library code with proper error propagation through optional `onError` callbacks. Library code should never silently log errors — callers need to be able to react to failures.

## Changes

- **`WebSocketCallbackClient`**: Add `onError` option to `WebSocketClientOptions`. Message parse errors and connection failures now call `onError` instead of `console.error`.
- **`RemoteConversation`**: Add `onError` option to `RemoteConversationOptions`. Threads it through to WebSocket client, state update callbacks, and event list callbacks.
- **`RemoteState`**: `createStateUpdateCallback()` now accepts optional `onError` parameter.
- **`RemoteEventsList`**: `createDefaultCallback()` now accepts optional `onError` parameter.
- **`SecretRegistry`**: Remove `console.error` from `CallableSecretSource.getValue()` and `exportSecretsForCommand()`. `getValue()` already returns `null` on failure which is the correct fallback behavior.
- **`index.ts`**: Export new `ErrorCallbackType`.

## Usage

```typescript
const conversation = new RemoteConversation(agent, workspace, {
  onError: (err) => myLogger.error('SDK error:', err),
});
```

If `onError` is not provided, errors are silently ignored (same behavior as before but without polluting `console`).

## Backward Compatibility

`onError` is optional — existing code continues to work unchanged. The only observable difference is that `console.error` is no longer called by library code.

Fixes #104

_This PR was created by an AI agent (OpenHands) on behalf of Robert Brennan._