### PR TITLE
fix: only register workspace-dependent tools when workspace supports them

### DIFF
--- a/src/conversation/conversation.ts
+++ b/src/conversation/conversation.ts
@@ -93,9 +93,6 @@ export function createConversation(config: CreateConversationOptions): IConversa
       );
 
     case 'local':
-      if (!(config.workspace instanceof LocalWorkspace)) {
-        throw new Error('Local conversation requires LocalWorkspace');
-      }
       return new LocalConversation(
         config.agent,
         config.workspace,

--- a/src/conversation/local-conversation.ts
+++ b/src/conversation/local-conversation.ts
@@ -19,6 +19,7 @@ import {
   Event,
 } from '../types/base';
 import { LocalWorkspace } from '../workspace/local-workspace';
+import { IWorkspace } from '../workspace/base';
 import { IConversation, IConversationState, IEventsList, BaseConversationOptions } from './base';
 import { ILLM, ChatMessage, Tool, ToolCall, TokenStreamEvent } from '../llm/base';
 import { generateSystemPrompt, TOOL_DESCRIPTIONS } from '../prompts';
@@ -177,10 +178,10 @@ class LocalConversationState implements IConversationState {
 }
 
 /**
- * Built-in tools available to the agent
- * Aligned with the Python SDK's tool definitions
+ * Built-in tools that require a functional workspace (execute_command, read_file, write_file).
+ * These are only registered when the workspace supports them (i.e., not a stub LocalWorkspace).
  */
-const BUILTIN_TOOLS: Tool[] = [
+const WORKSPACE_TOOLS: Tool[] = [
   {
     type: 'function',
     function: {
@@ -245,6 +246,13 @@ const BUILTIN_TOOLS: Tool[] = [
       },
     },
   },
+];
+
+/**
+ * Built-in tools that work without a functional workspace.
+ * These are always available when built-in tools are enabled.
+ */
+const STANDALONE_TOOLS: Tool[] = [
   {
     type: 'function',
     function: {
@@ -304,7 +312,7 @@ const BUILTIN_TOOLS: Tool[] = [
  */
 export class LocalConversation implements IConversation {
   public readonly agent: AgentBase;
-  public readonly workspace: LocalWorkspace;
+  public readonly workspace: IWorkspace;
   public readonly llm: ILLM;
 
   private _conversationId?: string;
@@ -329,7 +337,7 @@ export class LocalConversation implements IConversation {
   private stuckDetectionEnabled: boolean;
   private securityAnalyzer?: SecurityAnalyzer;
 
-  constructor(agent: AgentBase, workspace: LocalWorkspace, options: LocalConversationOptions) {
+  constructor(agent: AgentBase, workspace: IWorkspace, options: LocalConversationOptions) {
     this.agent = agent;
     this.workspace = workspace;
     this.llm = options.llm;
@@ -370,12 +378,25 @@ export class LocalConversation implements IConversation {
   }
 
   /**
+   * Check whether the workspace supports actual operations.
+   * LocalWorkspace is a stub that throws on all operations.
+   */
+  private workspaceIsStub(): boolean {
+    return this.workspace instanceof LocalWorkspace;
+  }
+
+  /**
    * Get the tools available to the agent.
+   * Workspace-dependent tools (execute_command, read_file, write_file) are only
+   * included when the workspace supports actual operations.
    */
   private getTools(): Tool[] {
     const tools: Tool[] = [];
     if (this.includeBuiltinTools) {
-      tools.push(...BUILTIN_TOOLS);
+      tools.push(...STANDALONE_TOOLS);
+      if (!this.workspaceIsStub()) {
+        tools.push(...WORKSPACE_TOOLS);
+      }
     }
     if (this.customTools) {
       tools.push(...this.customTools);


### PR DESCRIPTION
## Summary

`LocalWorkspace` is a stub that throws on all operations, but `LocalConversation` previously registered `execute_command`, `read_file`, and `write_file` tools that call workspace methods. This caused the agent to waste iterations on tools that always fail at runtime.

## Changes

- Split `BUILTIN_TOOLS` into `WORKSPACE_TOOLS` (execute_command, read_file, write_file) and `STANDALONE_TOOLS` (think, finish)
- `getTools()` only includes `WORKSPACE_TOOLS` when the workspace is not a stub `LocalWorkspace`
- Widen `LocalConversation.workspace` type from `LocalWorkspace` to `IWorkspace` — enables hybrid setups (local agent loop + remote workspace)
- Remove `instanceof LocalWorkspace` check from `createConversation` factory to match the more flexible workspace type

## Behavior

| Workspace | Built-in tools registered |
|-----------|-------------------------|
| `LocalWorkspace` (stub) | `think`, `finish` only |
| `RemoteWorkspace` or any `IWorkspace` | All 5: `execute_command`, `read_file`, `write_file`, `think`, `finish` |
| Custom tools provided | Custom tools + applicable built-in tools |
| `toolExecutor` provided | All tools routed to custom executor |

## Backward Compatibility

- `LocalConversation` constructor now accepts `IWorkspace` instead of only `LocalWorkspace` — this is a widening change, existing code passes type checking unchanged
- If users were relying on the (broken) workspace tools being registered with `LocalWorkspace`, they'll now see those tools absent. This is intentional — they never worked before.

Fixes #103

_This PR was created by an AI agent (OpenHands) on behalf of Robert Brennan._