### PR TITLE
fix: merge duplicate Event type hierarchies into single source of truth

### DIFF
--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -5,7 +5,7 @@
  * structured events for all conversation activities.
  */
 
-import { Message, MessageContent } from '../types/base';
+import { Message, MessageContent, Event } from '../types/base';
 
 /**
  * Event ID type - unique identifier for events
@@ -18,9 +18,10 @@ export type EventID = string;
 export type EventSource = 'agent' | 'user' | 'environment' | 'system' | 'hook';
 
 /**
- * Base interface for all conversation events
+ * Base interface for all rich conversation events.
+ * Extends the minimal Event interface from types/base.ts.
  */
-export interface BaseEvent {
+export interface BaseEvent extends Event {
   /** Unique event identifier */
   id: EventID;
   /** Event type/kind discriminator */

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,12 +74,12 @@ export type {
   EventID,
   EventSource,
   BaseEvent,
-  MessageEvent as TypedMessageEvent,
-  ActionEvent as TypedActionEvent,
-  ObservationEvent as TypedObservationEvent,
-  AgentErrorEvent as TypedAgentErrorEvent,
-  SystemPromptEvent as TypedSystemPromptEvent,
-  PauseEvent as TypedPauseEvent,
+  MessageEvent,
+  ActionEvent,
+  ObservationEvent,
+  AgentErrorEvent,
+  SystemPromptEvent,
+  PauseEvent,
   CondensationRequestEvent,
   CondensationSummaryEvent,
   CondensationEvent,
@@ -93,9 +93,9 @@ export type {
   StuckDetectionEvent,
   FinishEvent,
   ThinkEvent,
-  HookExecutionEvent as TypedHookExecutionEvent,
+  HookExecutionEvent,
   HookExecutionEventType,
-  ConversationEvent as TypedConversationEvent,
+  ConversationEvent,
 } from './events/types';
 
 // Hooks
@@ -142,12 +142,6 @@ export { HttpClient, HttpError } from './client/http-client';
 export type {
   ConversationID,
   Event,
-  MessageEvent,
-  ActionEvent,
-  ObservationEvent,
-  AgentErrorEvent,
-  SystemPromptEvent,
-  PauseEvent,
   Message,
   MessageContent,
   TextContent,
@@ -162,7 +156,6 @@ export type {
   SecretValue,
   ConversationStats,
   ConfirmationPolicyBase,
-  // Note: NeverConfirm and AlwaysConfirm classes are exported from security module
 } from './types/base';
 
 export type { AgentOptions } from './agent/agent';

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -4,50 +4,16 @@
 
 export type ConversationID = string;
 
+/**
+ * Base event interface matching the agent-server wire format.
+ * For rich, typed events use the specific types from events/types.ts
+ * (e.g., ActionEvent, ObservationEvent, ConversationEvent).
+ */
 export interface Event {
   id: string;
   kind: string;
   timestamp: string;
-  source?: 'agent' | 'user' | 'environment';
-  [key: string]: any;
-}
-
-// Specific event types for better type safety
-export interface MessageEvent extends Event {
-  kind: 'MessageEvent';
-  llm_message: Message;
-  activated_skills?: string[];
-}
-
-export interface ActionEvent extends Event {
-  kind: 'ActionEvent';
-  action: any; // The action object varies by action type
-}
-
-export interface ObservationEvent extends Event {
-  kind: 'ObservationEvent';
-  tool_name: string;
-  tool_call_id: string;
-  observation: any;
-  action_id: string;
-}
-
-export interface AgentErrorEvent extends Event {
-  kind: 'AgentErrorEvent';
-  tool_name: string;
-  tool_call_id: string;
-  observation: any;
-  action_id: string;
-}
-
-export interface SystemPromptEvent extends Event {
-  kind: 'SystemPromptEvent';
-  system_prompt: TextContent;
-  tools: any[];
-}
-
-export interface PauseEvent extends Event {
-  kind: 'PauseEvent';
+  source?: 'agent' | 'user' | 'environment' | 'system' | 'hook';
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary

`types/base.ts` and `events/types.ts` both defined overlapping event interfaces (`MessageEvent`, `ActionEvent`, etc.) with different levels of detail. The `types/base.ts` versions were sparse and incorrect (e.g., `AgentErrorEvent` had `observation`/`action_id` instead of `error`). `index.ts` had to export both sets with `Typed*` prefixes to avoid name collisions.

## Changes

- **`types/base.ts`**: Remove duplicate event subtypes (MessageEvent, ActionEvent, ObservationEvent, AgentErrorEvent, SystemPromptEvent, PauseEvent). Remove `[key: string]: any` index signature from `Event`. Widen `Event.source` to include `'system' | 'hook'`.
- **`events/types.ts`**: Make `BaseEvent` explicitly extend `Event` from `types/base.ts`, establishing a proper type hierarchy.
- **`index.ts`**: Export event subtypes from `events/types.ts` directly — no more `Typed*` prefix aliases.

## Migration

| Old import | New import |
|---|---|
| `TypedMessageEvent` | `MessageEvent` |
| `TypedActionEvent` | `ActionEvent` |
| `TypedObservationEvent` | `ObservationEvent` |
| `TypedAgentErrorEvent` | `AgentErrorEvent` |
| `TypedSystemPromptEvent` | `SystemPromptEvent` |
| `TypedPauseEvent` | `PauseEvent` |
| `TypedHookExecutionEvent` | `HookExecutionEvent` |
| `TypedConversationEvent` | `ConversationEvent` |

## Breaking Changes

- `Event` no longer has `[key: string]: any` — code that accessed arbitrary properties on `Event` without type narrowing will need to narrow to a specific event type first.
- `Typed*` aliases are removed. Downstream code importing `TypedMessageEvent` etc. should switch to the non-prefixed names.

Fixes #102

_This PR was created by an AI agent (OpenHands) on behalf of Robert Brennan._