### PR TITLE
fix: replace `[key: string]: any` index signatures with `unknown`

### DIFF
--- a/src/conversation/local-conversation.ts
+++ b/src/conversation/local-conversation.ts
@@ -716,8 +716,10 @@ export class LocalConversation implements IConversation {
   /**
    * Generate a title for the conversation using the LLM.
    */
-  async generateTitle(maxLength: number = 50, llm?: LLM): Promise<string> {
-    const llmToUse = llm || this.llm;
+  async generateTitle(maxLength: number = 50, _llm?: LLM): Promise<string> {
+    // LocalConversation always uses its own ILLM instance for title generation.
+    // The llm parameter exists for interface compatibility with RemoteConversation.
+    const llmToUse = this.llm;
 
     // Get a summary of the conversation
     const userMessages = this.messages

--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -187,7 +187,11 @@ export class RemoteConversation implements IConversation {
 
   async conversationStats(): Promise<ConversationStats> {
     const response = await this.client.get<ConversationInfo>(`/api/conversations/${this.id}`);
-    return response.data.stats;
+    const stats = response.data.stats ?? response.data.conversation_stats;
+    if (!stats) {
+      throw new Error('No conversation stats available');
+    }
+    return stats;
   }
 
   async sendMessage(message: string | Message): Promise<void> {

--- a/src/models/conversation.ts
+++ b/src/models/conversation.ts
@@ -28,10 +28,11 @@ export interface ConversationInfo {
   confirmation_policy: ConfirmationPolicyBase;
   activated_knowledge_skills: string[];
   agent: AgentBase;
-  workspace: any;
+  workspace: unknown;
   persistence_dir: string;
   conversation_stats?: ConversationStats;
-  stats?: any; // API returns stats instead of conversation_stats
+  /** API may return stats instead of conversation_stats */
+  stats?: ConversationStats;
   hook_config?: HookConfig | null;
   blocked_actions?: Record<string, string>;
   blocked_messages?: Record<string, string>;
@@ -42,7 +43,7 @@ export interface ConversationInfo {
    * @deprecated Use execution_status instead. This field is kept for backward compatibility.
    */
   status?: ConversationExecutionStatus;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface SendMessageRequest {

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -8,8 +8,8 @@ export interface Event {
   id: string;
   kind: string;
   timestamp: string;
-  source?: 'agent' | 'user' | 'environment';
-  [key: string]: any;
+  source?: 'agent' | 'user' | 'environment' | 'system' | 'hook';
+  [key: string]: unknown;
 }
 
 // Specific event types for better type safety
@@ -21,14 +21,14 @@ export interface MessageEvent extends Event {
 
 export interface ActionEvent extends Event {
   kind: 'ActionEvent';
-  action: any; // The action object varies by action type
+  action: Record<string, unknown>;
 }
 
 export interface ObservationEvent extends Event {
   kind: 'ObservationEvent';
   tool_name: string;
   tool_call_id: string;
-  observation: any;
+  observation: unknown;
   action_id: string;
 }
 
@@ -36,14 +36,14 @@ export interface AgentErrorEvent extends Event {
   kind: 'AgentErrorEvent';
   tool_name: string;
   tool_call_id: string;
-  observation: any;
+  observation: unknown;
   action_id: string;
 }
 
 export interface SystemPromptEvent extends Event {
   kind: 'SystemPromptEvent';
   system_prompt: TextContent;
-  tools: any[];
+  tools: unknown[];
 }
 
 export interface PauseEvent extends Event {
@@ -72,19 +72,18 @@ export interface ImageContent extends MessageContent {
 }
 
 export interface AgentContext {
-  skills?: any[];
+  skills?: unknown[];
   system_message_suffix?: string | null;
   user_message_suffix?: string | null;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface AgentBase {
   kind: string;
   llm: LLM;
   agent_context?: AgentContext | null;
-  // Keep name for backward compatibility
   name?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 // Alias for user-facing API
@@ -94,12 +93,12 @@ export interface LLM {
   model: string;
   api_key?: string;
   base_url?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface ServerInfo {
   version: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface Success {
@@ -145,12 +144,12 @@ export interface ConversationStats {
   message_events: number;
   action_events: number;
   observation_events: number;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface ConfirmationPolicyBase {
   type: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface NeverConfirm extends ConfirmationPolicyBase {


### PR DESCRIPTION
## Summary

All core interfaces used `[key: string]: any` index signatures, which defeated TypeScript's type system by making every property access resolve to `any`. This meant type errors were silently swallowed throughout the codebase.

## Changes

### `types/base.ts`
- Replace `[key: string]: any` with `[key: string]: unknown` in: `Event`, `AgentContext`, `AgentBase`, `LLM`, `ServerInfo`, `ConversationStats`, `ConfirmationPolicyBase`
- Replace bare `any` property types:
  - `ActionEvent.action`: `any` → `Record<string, unknown>`
  - `ObservationEvent.observation`: `any` → `unknown`
  - `AgentErrorEvent.observation`: `any` → `unknown`
  - `SystemPromptEvent.tools`: `any[]` → `unknown[]`
  - `AgentContext.skills`: `any[]` → `unknown[]`
- Widen `Event.source` to include `'system' | 'hook'`

### `models/conversation.ts`
- `ConversationInfo`: `[key: string]: any` → `[key: string]: unknown`
- `ConversationInfo.workspace`: `any` → `unknown`
- `ConversationInfo.stats`: `any` → `ConversationStats` (proper type)

### Bug fixes surfaced by stricter types
- `RemoteConversation.conversationStats()` — now properly handles `undefined` stats with fallback to `conversation_stats`
- `LocalConversation.generateTitle()` — parameter was `LLM` (config type) but tried to call `.generate()` on it; fixed to always use the internal `ILLM` instance

## Impact

Consumers can still pass objects with extra fields (the `unknown` index signature allows this), but they must narrow types before accessing dynamic properties. This prevents accidental `any` propagation through the type system.

Fixes #101

_This PR was created by an AI agent (OpenHands) on behalf of Robert Brennan._