### PR TITLE
Add OpenHands PR review workflows

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -1,0 +1,34 @@
+name: PR Review by OpenHands
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, labeled, review_requested]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr-review:
+    if: |
+      (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
+      (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
+      github.event.label.name == 'review-this' ||
+      github.event.requested_reviewer.login == 'openhands-agent' ||
+      github.event.requested_reviewer.login == 'all-hands-bot'
+    concurrency:
+      group: pr-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Run PR Review
+        uses: OpenHands/extensions/plugins/pr-review@main
+        with:
+          llm-model: ${{ secrets.LLM_MODEL || 'anthropic/claude-sonnet-4-5-20250929' }}
+          llm-base-url: ${{ secrets.LLM_BASE_URL || '' }}
+          use-sub-agents: 'true'
+          llm-api-key: ${{ secrets.LLM_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -1,0 +1,74 @@
+name: PR Review Evaluation
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-24.04
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      REPO_NAME: ${{ github.repository }}
+      PR_MERGED: ${{ github.event.pull_request.merged }}
+
+    steps:
+      - name: Download review trace artifact
+        id: download-trace
+        uses: dawidd6/action-download-artifact@v6
+        continue-on-error: true
+        with:
+          workflow: pr-review-by-openhands.yml
+          name: pr-review-trace-${{ github.event.pull_request.number }}
+          path: trace-info
+          search_artifacts: true
+          if_no_artifact_found: warn
+
+      - name: Check if trace file exists
+        id: check-trace
+        run: |
+          if [ -f "trace-info/laminar_trace_info.json" ]; then
+            echo "trace_exists=true" >> "$GITHUB_OUTPUT"
+            echo "Found trace file for PR #$PR_NUMBER"
+          else
+            echo "trace_exists=false" >> "$GITHUB_OUTPUT"
+            echo "No trace file found for PR #$PR_NUMBER - skipping evaluation"
+          fi
+
+      - name: Checkout extensions repository
+        if: steps.check-trace.outputs.trace_exists == 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: OpenHands/extensions
+          path: extensions
+
+      - name: Set up Python
+        if: steps.check-trace.outputs.trace_exists == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        if: steps.check-trace.outputs.trace_exists == 'true'
+        run: pip install lmnr
+
+      - name: Run evaluation
+        if: steps.check-trace.outputs.trace_exists == 'true'
+        env:
+          LMNR_PROJECT_API_KEY: ${{ secrets.LMNR_SKILLS_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python extensions/plugins/pr-review/scripts/evaluate_review.py \
+            --trace-file trace-info/laminar_trace_info.json
+
+      - name: Upload evaluation logs
+        if: always() && steps.check-trace.outputs.trace_exists == 'true'
+        uses: actions/upload-artifact@v5
+        with:
+          name: pr-review-evaluation-${{ github.event.pull_request.number }}
+          path: '*.log'
+          retention-days: 30


### PR DESCRIPTION
## Summary
- add the OpenHands PR review workflow from `OpenHands/extensions/plugins/pr-review`
- wire the workflow to this repository's `LLM_API_KEY`, optional `LLM_MODEL`/`LLM_BASE_URL`, and `GITHUB_TOKEN` secrets
- add the companion PR review evaluation workflow for Laminar trace follow-up

## Testing
- `npx prettier --check .github/workflows/pr-review-by-openhands.yml .github/workflows/pr-review-evaluation.yml`
- `npm test -- --runInBand`

Fixes #126.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f8cd9d90-6786-4360-9482-2e3015c7a8af)