### PR TITLE
chore: add sandbox community files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+<!-- Keep this PR as draft until it is ready for review. -->
+
+<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->
+
+- [ ] A human has tested these changes.
+
+---
+
+## Why
+
+<!-- Describe problem, motivation, etc. -->
+
+## Summary
+
+<!-- 1-3 bullets describing what changed. -->
+-
+
+## Issue Number
+
+<!-- Required if there is a relevant issue to this PR. -->
+
+## How to Test
+
+<!--
+Required. Share the steps for the reviewer to be able to test your PR.
+If you could not test this, say why.
+-->
+
+## Video/Screenshots
+
+<!-- Provide a video or screenshots for user-facing changes when applicable. -->
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Breaking change
+- [ ] Docs / chore
+
+## Notes
+
+<!-- Optional: migrations, config changes, rollout concerns, or follow-ups. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,158 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people.
+* Being respectful of differing opinions, viewpoints, and experiences.
+* Giving and gracefully accepting constructive feedback.
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience.
+* Focusing on what is best not just for us as individuals, but for the overall
+  community.
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind.
+* Trolling, insulting or derogatory comments, and personal or political attacks.
+* Public or private harassment.
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission.
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+contact@openhands.dev.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+### Slack Etiquettes
+
+These Slack etiquette guidelines are designed to foster an inclusive,
+respectful, and productive environment for all community members. By following
+these best practices, we ensure effective communication and collaboration while
+minimizing disruptions. Let’s work together to build a supportive and welcoming
+community!
+
+- Communicate respectfully and professionally, avoiding sarcasm or harsh
+  language, and remember that tone can be difficult to interpret in text.
+- Use threads for specific discussions to keep channels organized and easier to
+  follow.
+- Tag others only when their input is critical or urgent, and use @here,
+  @channel, or @everyone sparingly to minimize disruptions.
+- Be patient, as open-source contributors and maintainers often have other
+  commitments and may need time to respond.
+- Post questions or discussions in the most relevant channel.
+- When asking for help or raising issues, include necessary details like links,
+  screenshots, or clear explanations to provide context.
+- Keep discussions in public channels whenever possible to allow others to
+  benefit from the conversation, unless the matter is sensitive or private.
+- Always adhere to [our standards](./CODE_OF_CONDUCT.md#our-standards) to ensure
+  a welcoming and collaborative environment.
+- If you choose to mute a channel, consider setting up alerts for topics that
+  still interest you to stay engaged.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+Thanks for your interest in contributing to the OpenHands TypeScript client.
+This repository provides the browser-compatible TypeScript SDK for the
+OpenHands Agent Server.
+
+## Development setup
+
+### Prerequisites
+
+- Node.js 20+
+- npm 10+
+
+### Install dependencies
+
+```bash
+npm ci
+```
+
+## Common commands
+
+```bash
+npm run build
+npm run lint
+npm test
+```
+
+Integration tests require a running agent-server container and LLM credentials:
+
+```bash
+export LLM_API_KEY="your-api-key"
+export LLM_MODEL="anthropic/claude-sonnet-4-5-20250929"
+
+docker run -d --name agent-server -p 8010:8000 \
+  -v /tmp/agent-workspace:/workspace \
+  ghcr.io/openhands/agent-server:7c37803-python
+
+npm run test:integration
+```
+
+## Project guidelines
+
+- Keep code in `src/` browser-compatible; avoid Node.js built-in modules there.
+- Prefer focused, minimal changes over broad refactors.
+- Add or update tests when changing runtime behavior.
+- Keep the root SDK surface ergonomic; lower-level endpoint clients belong in
+  `@openhands/typescript-client/clients`.
+
+## Pull requests
+
+- Open focused PRs with a clear description of what changed and why.
+- Make sure the relevant checks pass before requesting review.
+- Use conventional prefixes in the PR title when possible, such as `feat`,
+  `fix`, `docs`, `refactor`, `test`, `build`, `ci`, or `chore`.
+- Include screenshots or recordings when changing user-facing example apps or
+  documentation visuals.
+
+## Need help?
+
+- Open a GitHub issue in this repository.
+- Reach out in the OpenHands community Slack: https://openhands.dev/joinslack
+- Review the main project docs: https://docs.all-hands.dev/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2025 OpenHands
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

We want the public `typescript-client` repo to meet the baseline OSS "sandbox" expectations before pursuing broader release work. The repository is currently missing several standard community-health files that GitHub surfaces as gaps.

## Summary

- add an MIT `LICENSE` file for the package repository
- add `CODE_OF_CONDUCT.md` and a repo-specific `CONTRIBUTING.md`
- add `.github/pull_request_template.md` to standardize future PRs

## Issue Number

N/A

## How to Test

- Review the new top-level community files for correctness and consistency.
- Optionally confirm the repo community profile improves after merge.

## Video/Screenshots

Not applicable.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

These are repository metadata/community-health changes only; no source code or package runtime behavior changed, so no automated tests were run.

_This PR description was created by an AI agent (OpenHands) on behalf of the user._