### PR TITLE
Support direct GitHub installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This client is **fully browser-compatible** and works without Node.js dependenci
 
 ## Installation
 
-This package is published to GitHub Packages. You have two installation options:
+This package is published to GitHub Packages. You can install it either from GitHub Packages or directly from this repository.
 
-### Option 1: Configure .npmrc (Recommended)
+### Option 1: Configure .npmrc
 
 Add this to your `.npmrc` file:
 
@@ -41,6 +41,14 @@ npm install @openhands/typescript-client
 ```bash
 npm install @openhands/typescript-client --registry=https://npm.pkg.github.com
 ```
+
+### Option 3: Install directly from the GitHub repository
+
+```bash
+npm install github:OpenHands/typescript-client
+```
+
+This git-based install runs the package `prepare` script during installation so the published `dist/` entrypoints and subpath exports are built automatically.
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openhands/typescript-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openhands/typescript-client",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@openrouter/sdk": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,21 @@
       "types": "./dist/clients.d.ts",
       "import": "./dist/clients.js",
       "default": "./dist/clients.js"
+    },
+    "./client/http-client": {
+      "types": "./dist/client/http-client.d.ts",
+      "import": "./dist/client/http-client.js",
+      "default": "./dist/client/http-client.js"
+    },
+    "./events/remote-events-list": {
+      "types": "./dist/events/remote-events-list.d.ts",
+      "import": "./dist/events/remote-events-list.js",
+      "default": "./dist/events/remote-events-list.js"
+    },
+    "./workspace/remote-workspace": {
+      "types": "./dist/workspace/remote-workspace.d.ts",
+      "import": "./dist/workspace/remote-workspace.js",
+      "default": "./dist/workspace/remote-workspace.js"
     }
   },
   "overrides": {
@@ -39,6 +54,7 @@
     "test:all": "npm run test && npm run test:integration",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run clean && npm run build && npm test"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- add a `prepare` script so git-based installs build `dist/` during installation
- expose the `client/http-client`, `events/remote-events-list`, and `workspace/remote-workspace` subpath exports used by downstream consumers
- document direct installation from `github:OpenHands/typescript-client` in the README
- refresh the root `package-lock.json` version metadata to match `package.json`

## Verification
- ran `npm install`
- ran `npm run build`
- verified a temporary consumer can install `git+file:///workspace/project/typescript-client` and resolve the root export, `./clients`, and the new subpath exports successfully

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/db86307f-fe49-4748-b3b3-ec0a74f59b4c)