### PR TITLE
Fix OpenHands PR review workflow auth

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -1,6 +1,15 @@
 name: PR Review by OpenHands
 
 on:
+  # Use pull_request_target to allow fork PRs to access secrets when triggered by maintainers.
+  # Security: This workflow runs when:
+  #   1. A new PR is opened (non-draft), OR
+  #   2. A draft PR is marked as ready for review, OR
+  #   3. A maintainer adds the 'review-this' label, OR
+  #   4. A maintainer requests openhands-agent or all-hands-bot as a reviewer
+  # Adding labels and requesting reviewers requires write access.
+  # The PR code is explicitly checked out for review, but secrets are only accessible
+  # because the workflow runs in the base repository context.
   pull_request_target:
     types: [opened, ready_for_review, labeled, review_requested]
 
@@ -11,6 +20,12 @@ permissions:
 
 jobs:
   pr-review:
+    # Run when one of the following conditions is met:
+    #   1. A new non-draft PR is opened by a non-first-time contributor, OR
+    #   2. A draft PR is converted to ready for review by a non-first-time contributor, OR
+    #   3. 'review-this' label is added, OR
+    #   4. openhands-agent or all-hands-bot is requested as a reviewer
+    # Note: FIRST_TIME_CONTRIBUTOR and NONE PRs require manual trigger via label/reviewer request.
     if: |
       (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
       (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
@@ -26,9 +41,9 @@ jobs:
       - name: Run PR Review
         uses: OpenHands/extensions/plugins/pr-review@main
         with:
-          llm-model: ${{ secrets.LLM_MODEL || 'anthropic/claude-sonnet-4-5-20250929' }}
-          llm-base-url: ${{ secrets.LLM_BASE_URL || '' }}
+          llm-model: litellm_proxy/claude-sonnet-4-5-20250929
+          llm-base-url: https://llm-proxy.app.all-hands.dev
           use-sub-agents: 'true'
           llm-api-key: ${{ secrets.LLM_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
           lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Summary
- switch the PR review workflow to the org-standard LiteLLM proxy model/base URL used by other OpenHands repos
- use the shared `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` secret for review comments instead of the default `GITHUB_TOKEN`
- add the same trigger/security comments used in other working OpenHands repositories for consistency

## Why
The current workflow is configured differently from other OpenHands repos and fails with `litellm.AuthenticationError` during the OpenHands review step.

## Verification
- compared `.github/workflows/pr-review-by-openhands.yml` against working configurations in `OpenHands/extensions`, `OpenHands/docs`, `OpenHands/benchmarks`, and `OpenHands/software-agent-sdk`
- confirmed the failing run for `OpenHands/typescript-client#130` errors with `litellm.AuthenticationError`

_This PR was created by an AI agent (OpenHands) on behalf of the user._