### PR TITLE
Fix git dependency package imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node ./scripts/rewrite-relative-imports.mjs",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
-    "format": "prettier --write \"src/**/*.ts\" \"examples/**/*.ts\"",
-    "format:check": "prettier --check \"src/**/*.ts\" \"examples/**/*.ts\"",
+    "format": "prettier --write \"src/**/*.ts\" \"examples/**/*.ts\" \"scripts/**/*.mjs\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"examples/**/*.ts\" \"scripts/**/*.mjs\"",
     "test": "jest --config jest.config.cjs",
     "test:watch": "jest --config jest.config.cjs --watch",
     "test:coverage": "jest --config jest.config.cjs --coverage",
@@ -51,11 +51,12 @@
     "test:integration:verbose": "jest --config jest.integration.config.cjs --verbose",
     "test:integration:deterministic": "jest --config jest.integration.config.cjs --runInBand --testPathPatterns=\"deterministic-api.integration.test.ts|bash.integration.test.ts\"",
     "test:integration:llm": "jest --config jest.integration.config.cjs --runInBand --testPathIgnorePatterns=\"deterministic-api.integration.test.ts|bash.integration.test.ts\"",
-    "test:all": "npm run test && npm run test:integration",
+    "test:git-dependency": "node ./scripts/smoke-test-git-dependency.mjs",
+    "test:all": "npm run test && npm run test:integration && npm run test:git-dependency",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
-    "prepare": "npm run build",
-    "prepublishOnly": "npm run clean && npm run build && npm test"
+    "prepare": "npm run clean && npm run build",
+    "prepublishOnly": "npm test"
   },
   "keywords": [
     "openhands",

--- a/scripts/rewrite-relative-imports.mjs
+++ b/scripts/rewrite-relative-imports.mjs
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from 'node:fs';
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -9,9 +10,15 @@ const TARGET_SUFFIXES = ['.js', '.d.ts', '.d.mts', '.d.cts'];
 
 const hasKnownExtension = (specifier) => KNOWN_EXTENSIONS.has(path.posix.extname(specifier));
 
-const normalizeRelativeSpecifier = (specifier) => {
+const normalizeRelativeSpecifier = (specifier, filePath) => {
   if (!specifier.startsWith('.') || hasKnownExtension(specifier)) {
     return specifier;
+  }
+
+  const resolvedSpecifierPath = path.resolve(path.dirname(filePath), specifier);
+
+  if (existsSync(resolvedSpecifierPath) && statSync(resolvedSpecifierPath).isDirectory()) {
+    return `${specifier}/index.js`;
   }
 
   return `${specifier}.js`;
@@ -38,7 +45,7 @@ const rewriteFile = async (filePath) => {
   const rewritten = original.replace(
     IMPORT_EXPORT_SPECIFIER_PATTERN,
     (_fullMatch, prefix, quote, specifier) => {
-      const normalizedSpecifier = normalizeRelativeSpecifier(specifier);
+      const normalizedSpecifier = normalizeRelativeSpecifier(specifier, filePath);
       return `${prefix}${quote}${normalizedSpecifier}${quote}`;
     }
   );

--- a/scripts/rewrite-relative-imports.mjs
+++ b/scripts/rewrite-relative-imports.mjs
@@ -1,0 +1,60 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIST_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist');
+const IMPORT_EXPORT_SPECIFIER_PATTERN = /(from\s+|import\s*\()(['"])(\.[^'"]+)\2/g;
+const KNOWN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.json', '.node']);
+const TARGET_SUFFIXES = ['.js', '.d.ts', '.d.mts', '.d.cts'];
+
+const hasKnownExtension = (specifier) => KNOWN_EXTENSIONS.has(path.posix.extname(specifier));
+
+const normalizeRelativeSpecifier = (specifier) => {
+  if (!specifier.startsWith('.') || hasKnownExtension(specifier)) {
+    return specifier;
+  }
+
+  return `${specifier}.js`;
+};
+
+const walk = async (directory) => {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const resolvedPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return walk(resolvedPath);
+      }
+
+      return resolvedPath;
+    })
+  );
+
+  return files.flat();
+};
+
+const rewriteFile = async (filePath) => {
+  const original = await readFile(filePath, 'utf8');
+  const rewritten = original.replace(
+    IMPORT_EXPORT_SPECIFIER_PATTERN,
+    (_fullMatch, prefix, quote, specifier) => {
+      const normalizedSpecifier = normalizeRelativeSpecifier(specifier);
+      return `${prefix}${quote}${normalizedSpecifier}${quote}`;
+    }
+  );
+
+  if (rewritten !== original) {
+    await writeFile(filePath, rewritten);
+  }
+};
+
+const main = async () => {
+  const files = await walk(DIST_DIR);
+  await Promise.all(
+    files
+      .filter((filePath) => TARGET_SUFFIXES.some((suffix) => filePath.endsWith(suffix)))
+      .map(rewriteFile)
+  );
+};
+
+await main();

--- a/scripts/smoke-test-git-dependency.mjs
+++ b/scripts/smoke-test-git-dependency.mjs
@@ -1,0 +1,52 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tempDir = await mkdtemp(path.join(os.tmpdir(), 'openhands-typescript-client-gitdep-'));
+const dependencyUrl = `git+${pathToFileURL(repoRoot).href}`;
+
+try {
+  await writeFile(
+    path.join(tempDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'openhands-typescript-client-gitdep-smoke',
+        private: true,
+        type: 'module',
+        dependencies: {
+          '@openhands/typescript-client': dependencyUrl,
+        },
+      },
+      null,
+      2
+    )
+  );
+
+  execFileSync('npm', ['install', '--no-fund', '--no-audit'], {
+    cwd: tempDir,
+    stdio: 'inherit',
+  });
+
+  execFileSync(
+    'node',
+    [
+      '--input-type=module',
+      '-e',
+      [
+        "import { Conversation } from '@openhands/typescript-client';",
+        "import { ServerClient } from '@openhands/typescript-client/clients';",
+        "import { HttpClient } from '@openhands/typescript-client/client/http-client';",
+        'console.log(typeof Conversation, typeof ServerClient, typeof HttpClient);',
+      ].join('\n'),
+    ],
+    {
+      cwd: tempDir,
+      stdio: 'inherit',
+    }
+  );
+} finally {
+  await rm(tempDir, { recursive: true, force: true });
+}

--- a/scripts/smoke-test-git-dependency.mjs
+++ b/scripts/smoke-test-git-dependency.mjs
@@ -36,10 +36,11 @@ try {
       '--input-type=module',
       '-e',
       [
-        "import { Conversation } from '@openhands/typescript-client';",
         "import { ServerClient } from '@openhands/typescript-client/clients';",
         "import { HttpClient } from '@openhands/typescript-client/client/http-client';",
-        'console.log(typeof Conversation, typeof ServerClient, typeof HttpClient);',
+        "import { RemoteEventsList } from '@openhands/typescript-client/events/remote-events-list';",
+        "import { RemoteWorkspace } from '@openhands/typescript-client/workspace/remote-workspace';",
+        'console.log(typeof ServerClient, typeof HttpClient, typeof RemoteEventsList, typeof RemoteWorkspace);',
       ].join('\n'),
     ],
     {


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Installing the TypeScript client from a git dependency already builds `dist/`, but the emitted ESM keeps extensionless relative imports such as `./client/server-client` and directory barrels such as `./hooks`. Node cannot resolve those paths when the package is consumed directly from GitHub, which breaks downstream imports like `@openhands/typescript-client/clients`.

## Summary

- rewrite emitted `dist/` import/export specifiers after `tsc` so relative file imports become `.js` and directory barrels become `/index.js`
- keep `prepare` building a clean `dist/` and add a `test:git-dependency` smoke test that installs the repo via `git+file://...`
- include the new scripts in format checks and simplify `prepublishOnly` to rely on the build done during `prepare`

## Issue Number

N/A (related to OpenHands/agent-server-gui#16)

## How to Test

- `npm install --no-fund --no-audit`
- `npm run build`
- `npm test -- --runInBand`
- `npm run test:git-dependency`

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This PR was created by an AI agent (OpenHands) on behalf of the user.
- This PR specifically fixes the git-installed subpath exports used by downstream consumers such as `agent-server-gui`.


@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d7bb27ea-f575-4615-a3de-ad9cb13cf688)