### PR TITLE
fix(server-client): align `/health` response shape with agent-server JSON payload

### DIFF
--- a/src/__tests__/integration/deterministic-api.integration.test.ts
+++ b/src/__tests__/integration/deterministic-api.integration.test.ts
@@ -58,7 +58,7 @@ describe('Deterministic API Integration Tests', () => {
 
       expect(root).toBeDefined();
       expect(alive.status).toBe('ok');
-      expect(health).toBe('OK');
+      expect(health.status).toBe('ok');
       expect(['ready', 'initializing']).toContain(ready.status);
       expect(info.version).toBeDefined();
       expect(Array.isArray(providers)).toBe(true);

--- a/src/client/server-client.ts
+++ b/src/client/server-client.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from './http-client';
-import { AliveStatus, ReadyStatus } from '../models/api';
+import { AliveStatus, HealthStatus, ReadyStatus } from '../models/api';
 import { ServerInfo } from '../types/base';
 
 export interface ServerClientOptions {
@@ -33,8 +33,8 @@ export class ServerClient {
     return response.data;
   }
 
-  async getHealth(): Promise<string> {
-    const response = await this.client.get<string>('/health');
+  async getHealth(): Promise<HealthStatus> {
+    const response = await this.client.get<HealthStatus>('/health');
     return response.data;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,7 @@ export type { HttpClientOptions, RequestOptions, HttpResponse } from './client/h
 
 export type {
   AliveStatus,
+  HealthStatus,
   ReadyStatus,
   ProvidersResponse,
   ModelsResponse,

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -6,6 +6,10 @@ export interface AliveStatus {
   status: string;
 }
 
+export interface HealthStatus {
+  status: string;
+}
+
 export interface ReadyStatus {
   status: string;
   message?: string;

--- a/swagger-doc.json
+++ b/swagger-doc.json
@@ -18,7 +18,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
               }
             }
           }
@@ -38,8 +40,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string",
-                  "title": "Response Health Health Get"
+                  "$ref": "#/components/schemas/HealthStatus"
                 }
               }
             }
@@ -2177,7 +2178,7 @@
         },
         "type": "object",
         "title": "AgentContext",
-        "description": "Central structure for managing prompt extension.\n\nAgentContext unifies all the contextual inputs that shape how the system\nextends and interprets user prompts. It combines both static environment\ndetails and dynamic, user-activated extensions from skills.\n\nSpecifically, it provides:\n- **Repository context / Repo Skills**: Information about the active codebase,\n  branches, and repo-specific instructions contributed by repo skills.\n- **Runtime context**: Current execution environment (hosts, working\n  directory, secrets, date, etc.).\n- **Conversation instructions**: Optional task- or channel-specific rules\n  that constrain or guide the agent’s behavior across the session.\n- **Knowledge Skills**: Extensible components that can be triggered by user input\n  to inject knowledge or domain-specific guidance.\n\nTogether, these elements make AgentContext the primary container responsible\nfor assembling, formatting, and injecting all prompt-relevant context into\nLLM interactions."
+        "description": "Central structure for managing prompt extension.\n\nAgentContext unifies all the contextual inputs that shape how the system\nextends and interprets user prompts. It combines both static environment\ndetails and dynamic, user-activated extensions from skills.\n\nSpecifically, it provides:\n- **Repository context / Repo Skills**: Information about the active codebase,\n  branches, and repo-specific instructions contributed by repo skills.\n- **Runtime context**: Current execution environment (hosts, working\n  directory, secrets, date, etc.).\n- **Conversation instructions**: Optional task- or channel-specific rules\n  that constrain or guide the agent\u2019s behavior across the session.\n- **Knowledge Skills**: Extensible components that can be triggered by user input\n  to inject knowledge or domain-specific guidance.\n\nTogether, these elements make AgentContext the primary container responsible\nfor assembling, formatting, and injecting all prompt-relevant context into\nLLM interactions."
       },
       "AgentErrorEvent": {
         "properties": {
@@ -3415,7 +3416,7 @@
               }
             ],
             "title": "Timeout",
-            "description": "Optional. Sets a maximum time limit (in seconds) for running the command. If the command takes longer than this limit, you’ll be asked whether to continue or stop it. If you don’t set a value, the command will instead pause and ask for confirmation when it produces no new output for 30 seconds. Use a higher value if the command is expected to take a long time (like installation or testing), or if it has a known fixed duration (like sleep)."
+            "description": "Optional. Sets a maximum time limit (in seconds) for running the command. If the command takes longer than this limit, you\u2019ll be asked whether to continue or stop it. If you don\u2019t set a value, the command will instead pause and ask for confirmation when it produces no new output for 30 seconds. Use a higher value if the command is expected to take a long time (like installation or testing), or if it has a known fixed duration (like sleep)."
           },
           "reset": {
             "type": "boolean",
@@ -6251,6 +6252,19 @@
           }
         },
         "title": "Observation"
+      },
+      "HealthStatus": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "HealthStatus"
       }
     }
   }


### PR DESCRIPTION
## Why

[OpenHands/software-agent-sdk#2883](https://github.com/OpenHands/software-agent-sdk/pull/2883) standardizes `/alive` and `/health` on the agent-server to return the same JSON envelope:

```json
{"status": "ok"}
```

Previously `/health` returned a plain string, while `/alive` already returned JSON. With that PR merged, the TypeScript client's `ServerClient.getHealth()` is no longer accurate — it's typed as `Promise<string>`, but the runtime response is now an object — and the deterministic-API integration test would fail.

## What

- Add a `HealthStatus` type (`{ status: string }`) that mirrors the agent-server model, and re-export it from the package entry point.
- Type `ServerClient.getHealth()` as `Promise<HealthStatus>` (was `Promise<string>`).
- Fix the deterministic API integration test to assert `health.status === 'ok'`. The previous `expect(health).toBe('OK')` literal was already incorrect against the existing string body (`'ok'`, not `'OK'`), and is definitely incorrect against the new JSON shape.
- Refresh `swagger-doc.json` so both `/alive` and `/health` reference the new `HealthStatus` schema.

## Compatibility

This is a typed breaking change for any direct consumer of `ServerClient.getHealth()`:

- Old: `const status: string = await server.getHealth();` → `'ok'`
- New: `const { status } = await server.getHealth();` → `'ok'`

Plain liveness probes that only care about HTTP status (e.g. `await server.getHealth()` followed by no body inspection) continue to work. The change matches the now-stable agent-server contract and matches the existing `getAlive()` shape.

## Testing

- `npm run build` ✅
- `npm run test` ✅ (163/163)
- `npm run lint` ✅
- `npm run format:check` ✅

## Notes

- This PR was created by an AI agent (OpenHands) on behalf of @neubig as part of post-merge cleanup for the agent-server change. See [OpenHands/software-agent-sdk#2883](https://github.com/OpenHands/software-agent-sdk/pull/2883).


@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3c15404c-5168-4f95-a8f2-00071e9f1314)