### PR TITLE
feat(profiles): add ProfilesClient and RemoteConversation.switchLlm

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -1,5 +1,13 @@
-import { ConversationManager, HttpClient, Workspace } from '../index';
-import { BashClient, ServerClient, SkillsClient } from '../clients';
+import {
+  Agent,
+  ConversationManager,
+  HttpClient,
+  HttpError,
+  RemoteConversation,
+  RemoteWorkspace,
+  Workspace,
+} from '../index';
+import { BashClient, ProfilesClient, ServerClient, SkillsClient } from '../clients';
 
 const originalFetch = global.fetch;
 
@@ -14,8 +22,11 @@ describe('Auxiliary API clients', () => {
 
     expect(manager.server).toBeInstanceOf(ServerClient);
     expect(manager.skills).toBeInstanceOf(SkillsClient);
+    expect(manager.profiles).toBeInstanceOf(ProfilesClient);
     expect(manager.server.host).toBe('http://example.com');
     expect(manager.server.apiKey).toBe('secret');
+    expect(manager.profiles.host).toBe('http://example.com');
+    expect(manager.profiles.apiKey).toBe('secret');
   });
 
   it('Workspace exposes bash namespace', () => {
@@ -93,6 +104,251 @@ describe('Auxiliary API clients', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ command: 'echo hi', cwd: '/tmp', timeout: 3 }),
+      })
+    );
+  });
+
+  it('ProfilesClient.listProfiles GETs the profiles endpoint', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          profiles: [{ name: 'default', model: 'gpt-4o', api_key_set: true }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const result = await client.listProfiles();
+
+    expect(result.profiles).toHaveLength(1);
+    expect(result.profiles[0].name).toBe('default');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/profiles',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('ProfilesClient.getProfile sends X-Expose-Secrets header when requested', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: 'default',
+          config: { model: 'gpt-4o', api_key: 'sk-x' },
+          api_key_set: true,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const result = await client.getProfile('default', { exposeSecrets: 'plaintext' });
+
+    expect(result.name).toBe('default');
+    expect(result.api_key_set).toBe(true);
+    const fetchMock = global.fetch as jest.Mock;
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://example.com/api/profiles/default');
+    expect(init.method).toBe('GET');
+    expect(init.headers['X-Expose-Secrets']).toBe('plaintext');
+  });
+
+  it('ProfilesClient.getProfile omits X-Expose-Secrets header by default', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ name: 'default', config: { model: 'gpt-4o' }, api_key_set: false }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    await client.getProfile('default');
+
+    const fetchMock = global.fetch as jest.Mock;
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers['X-Expose-Secrets']).toBeUndefined();
+  });
+
+  it('ProfilesClient.getProfile percent-encodes the profile name', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ name: 'my profile', config: {}, api_key_set: false }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    await client.getProfile('my profile');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/profiles/my%20profile',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('ProfilesClient.saveProfile POSTs the profile body', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ name: 'default', message: "Profile 'default' saved" }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const result = await client.saveProfile('default', {
+      llm: { model: 'gpt-4o', api_key: 'sk-secret' },
+      include_secrets: true,
+    });
+
+    expect(result.name).toBe('default');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/profiles/default',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          llm: { model: 'gpt-4o', api_key: 'sk-secret' },
+          include_secrets: true,
+        }),
+      })
+    );
+  });
+
+  it('ProfilesClient.deleteProfile DELETEs the profile endpoint', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ name: 'default', message: "Profile 'default' deleted" }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const result = await client.deleteProfile('default');
+
+    expect(result.name).toBe('default');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/profiles/default',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
+  it('ProfilesClient.renameProfile POSTs to the rename endpoint', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ name: 'new', message: "Profile 'old' renamed to 'new'" }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const result = await client.renameProfile('old', 'new');
+
+    expect(result.name).toBe('new');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/profiles/old/rename',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ new_name: 'new' }),
+      })
+    );
+  });
+
+  it('ProfilesClient.getProfile sends X-Expose-Secrets: encrypted', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: 'default',
+          config: { model: 'gpt-4o', api_key: 'gAAAAA-encrypted-blob' },
+          api_key_set: true,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const result = await client.getProfile('default', { exposeSecrets: 'encrypted' });
+
+    expect(result.config.api_key).toBe('gAAAAA-encrypted-blob');
+    const fetchMock = global.fetch as jest.Mock;
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers['X-Expose-Secrets']).toBe('encrypted');
+  });
+
+  it('ProfilesClient.getProfile surfaces HttpError on 404', async () => {
+    global.fetch = jest.fn(
+      async () =>
+        new Response(JSON.stringify({ detail: "Profile 'missing' not found" }), {
+          status: 404,
+          statusText: 'Not Found',
+          headers: { 'content-type': 'application/json' },
+        })
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const error = await client.getProfile('missing').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(404);
+    expect((error as HttpError).response).toEqual({ detail: "Profile 'missing' not found" });
+  });
+
+  it('ProfilesClient.saveProfile omits include_secrets when not provided', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ name: 'default', message: "Profile 'default' saved" }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    await client.saveProfile('default', { llm: { model: 'gpt-4o' } });
+
+    const fetchMock = global.fetch as jest.Mock;
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({ llm: { model: 'gpt-4o' } });
+    expect(body).not.toHaveProperty('include_secrets');
+  });
+
+  it('ProfilesClient.renameProfile percent-encodes the source name', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ name: 'fresh', message: 'renamed' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    await client.renameProfile('my profile', 'fresh');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/profiles/my%20profile/rename',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('RemoteConversation.switchLlm POSTs the llm to the switch_llm endpoint', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const agent = new Agent({ llm: { model: 'gpt-4o', api_key: 'k' } });
+    const workspace = new RemoteWorkspace({ host: 'http://example.com', workingDir: '/tmp' });
+    const conversation = new RemoteConversation(agent, workspace, {
+      conversationId: 'conv-123',
+    });
+
+    const llm = { model: 'gpt-4o-mini', api_key: 'sk-new' };
+    await conversation.switchLlm(llm);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conv-123/switch_llm',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ llm }),
       })
     );
   });

--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -327,6 +327,32 @@ describe('Auxiliary API clients', () => {
     );
   });
 
+  it('ProfilesClient.activateProfile POSTs to the activate endpoint', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          name: 'default',
+          message: "Profile 'default' activated and applied to current settings",
+          llm_applied: true,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const result = await client.activateProfile('my profile');
+
+    expect(result.name).toBe('default');
+    expect(result.llm_applied).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/profiles/my%20profile/activate',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{}',
+      })
+    );
+  });
+
   it('RemoteConversation.switchLlm POSTs the llm to the switch_llm endpoint', async () => {
     global.fetch = jest.fn().mockResolvedValue(
       new Response(JSON.stringify({ success: true }), {

--- a/src/client/profiles-client.ts
+++ b/src/client/profiles-client.ts
@@ -1,0 +1,84 @@
+import { HttpClient } from './http-client';
+import {
+  ExposeSecretsMode,
+  ProfileDetailResponse,
+  ProfileListResponse,
+  ProfileMutationResponse,
+  SaveProfileRequest,
+} from '../models/api';
+
+export interface ProfilesClientOptions {
+  host: string;
+  apiKey?: string;
+  timeout?: number;
+}
+
+export interface GetProfileOptions {
+  /**
+   * Controls server-side secret exposure via the ``X-Expose-Secrets`` header:
+   * - ``encrypted``: cipher-encrypted values (safe for frontend round-trip)
+   * - ``plaintext``: raw secret values (backend clients only)
+   * - omitted: ``api_key`` is nulled, with ``api_key_set`` indicator
+   */
+  exposeSecrets?: ExposeSecretsMode;
+}
+
+export class ProfilesClient {
+  public readonly host: string;
+  public readonly apiKey?: string;
+  private readonly client: HttpClient;
+
+  constructor(options: ProfilesClientOptions) {
+    this.host = options.host.replace(/\/$/, '');
+    this.apiKey = options.apiKey;
+    this.client = new HttpClient({
+      baseUrl: this.host,
+      apiKey: this.apiKey,
+      timeout: options.timeout || 60000,
+    });
+  }
+
+  async listProfiles(): Promise<ProfileListResponse> {
+    const response = await this.client.get<ProfileListResponse>('/api/profiles');
+    return response.data;
+  }
+
+  async getProfile(name: string, options: GetProfileOptions = {}): Promise<ProfileDetailResponse> {
+    const headers: Record<string, string> = {};
+    if (options.exposeSecrets) {
+      headers['X-Expose-Secrets'] = options.exposeSecrets;
+    }
+    const response = await this.client.get<ProfileDetailResponse>(
+      `/api/profiles/${encodeURIComponent(name)}`,
+      { headers }
+    );
+    return response.data;
+  }
+
+  async saveProfile(name: string, request: SaveProfileRequest): Promise<ProfileMutationResponse> {
+    const response = await this.client.post<ProfileMutationResponse>(
+      `/api/profiles/${encodeURIComponent(name)}`,
+      request
+    );
+    return response.data;
+  }
+
+  async deleteProfile(name: string): Promise<ProfileMutationResponse> {
+    const response = await this.client.delete<ProfileMutationResponse>(
+      `/api/profiles/${encodeURIComponent(name)}`
+    );
+    return response.data;
+  }
+
+  async renameProfile(name: string, newName: string): Promise<ProfileMutationResponse> {
+    const response = await this.client.post<ProfileMutationResponse>(
+      `/api/profiles/${encodeURIComponent(name)}/rename`,
+      { new_name: newName }
+    );
+    return response.data;
+  }
+
+  close(): void {
+    this.client.close();
+  }
+}

--- a/src/client/profiles-client.ts
+++ b/src/client/profiles-client.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from './http-client';
 import {
+  ActivateProfileResponse,
   ExposeSecretsMode,
   ProfileDetailResponse,
   ProfileListResponse,
@@ -74,6 +75,14 @@ export class ProfilesClient {
     const response = await this.client.post<ProfileMutationResponse>(
       `/api/profiles/${encodeURIComponent(name)}/rename`,
       { new_name: newName }
+    );
+    return response.data;
+  }
+
+  async activateProfile(name: string): Promise<ActivateProfileResponse> {
+    const response = await this.client.post<ActivateProfileResponse>(
+      `/api/profiles/${encodeURIComponent(name)}/activate`,
+      {}
     );
     return response.data;
   }

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,6 +1,7 @@
 export { ServerClient } from './client/server-client';
 export { BashClient } from './client/bash-client';
 export { LLMMetadataClient } from './client/llm-client';
+export { ProfilesClient } from './client/profiles-client';
 export { SettingsClient } from './client/settings-client';
 export { SkillsClient } from './client/skills-client';
 export { ToolClient } from './client/tool-client';
@@ -10,6 +11,7 @@ export { DesktopClient } from './client/desktop-client';
 export type { ServerClientOptions } from './client/server-client';
 export type { BashClientOptions } from './client/bash-client';
 export type { LLMMetadataClientOptions } from './client/llm-client';
+export type { ProfilesClientOptions, GetProfileOptions } from './client/profiles-client';
 export type { SettingsClientOptions } from './client/settings-client';
 export type { SkillsClientOptions } from './client/skills-client';
 export type { ToolClientOptions } from './client/tool-client';

--- a/src/conversation/conversation-manager.ts
+++ b/src/conversation/conversation-manager.ts
@@ -5,6 +5,7 @@
 import { HttpClient } from '../client/http-client';
 import { DesktopClient } from '../client/desktop-client';
 import { LLMMetadataClient } from '../client/llm-client';
+import { ProfilesClient } from '../client/profiles-client';
 import { ServerClient } from '../client/server-client';
 import { SettingsClient } from '../client/settings-client';
 import { SkillsClient } from '../client/skills-client';
@@ -73,6 +74,7 @@ export class ConversationManager {
   public readonly apiKey?: string;
   public readonly server: ServerClient;
   public readonly llm: LLMMetadataClient;
+  public readonly profiles: ProfilesClient;
   public readonly settings: SettingsClient;
   public readonly skills: SkillsClient;
   public readonly tools: ToolClient;
@@ -97,6 +99,7 @@ export class ConversationManager {
 
     this.server = new ServerClient(clientOptions);
     this.llm = new LLMMetadataClient(clientOptions);
+    this.profiles = new ProfilesClient(clientOptions);
     this.settings = new SettingsClient(clientOptions);
     this.skills = new SkillsClient(clientOptions);
     this.tools = new ToolClient(clientOptions);
@@ -359,6 +362,7 @@ export class ConversationManager {
   close(): void {
     this.server.close();
     this.llm.close();
+    this.profiles.close();
     this.settings.close();
     this.skills.close();
     this.tools.close();

--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -293,6 +293,15 @@ export class RemoteConversation implements IConversation {
   }
 
   /**
+   * Swap the conversation's LLM to a caller-supplied object. For app-servers
+   * that own the LLM directly and don't push profiles to the agent-server's
+   * filesystem.
+   */
+  async switchLlm(llm: LLM): Promise<void> {
+    await this.client.post(`/api/conversations/${this.id}/switch_llm`, { llm });
+  }
+
+  /**
    * Fork the current conversation and return a new RemoteConversation instance.
    */
   async fork(request: ForkConversationRequest = {}): Promise<RemoteConversation> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,6 +247,13 @@ export type {
   DesktopUrlResponse,
   VSCodeUrlResponse,
   VSCodeStatusResponse,
+  ProfileInfo,
+  ProfileListResponse,
+  ProfileDetailResponse,
+  ProfileMutationResponse,
+  SaveProfileRequest,
+  RenameProfileRequest,
+  ExposeSecretsMode,
 } from './models/api';
 
 export type { WebSocketClientOptions } from './events/websocket-client';

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,7 @@ export type {
   ProfileListResponse,
   ProfileDetailResponse,
   ProfileMutationResponse,
+  ActivateProfileResponse,
   SaveProfileRequest,
   RenameProfileRequest,
   ExposeSecretsMode,

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -2,6 +2,8 @@
  * Models for auxiliary Agent Server APIs.
  */
 
+import { LLM } from '../types/base';
+
 export interface AliveStatus {
   status: string;
 }
@@ -120,7 +122,7 @@ export interface ActivateProfileResponse {
 }
 
 export interface SaveProfileRequest {
-  llm: Record<string, unknown>;
+  llm: LLM;
   include_secrets?: boolean;
 }
 

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -94,14 +94,14 @@ export interface VSCodeStatusResponse {
 
 export interface ProfileInfo {
   name: string;
-  model?: string | null;
-  base_url?: string | null;
-  api_key_set?: boolean;
+  model: string | null;
+  base_url: string | null;
+  api_key_set: boolean;
 }
 
 export interface ProfileListResponse {
   profiles: ProfileInfo[];
-  active_profile?: string | null;
+  active_profile: string | null;
 }
 
 export interface ProfileDetailResponse {

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -99,6 +99,7 @@ export interface ProfileInfo {
 
 export interface ProfileListResponse {
   profiles: ProfileInfo[];
+  active_profile?: string | null;
 }
 
 export interface ProfileDetailResponse {
@@ -110,6 +111,12 @@ export interface ProfileDetailResponse {
 export interface ProfileMutationResponse {
   name: string;
   message: string;
+}
+
+export interface ActivateProfileResponse {
+  name: string;
+  message: string;
+  llm_applied: boolean;
 }
 
 export interface SaveProfileRequest {

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -89,3 +89,36 @@ export interface VSCodeStatusResponse {
   enabled: boolean;
   message?: string;
 }
+
+export interface ProfileInfo {
+  name: string;
+  model?: string | null;
+  base_url?: string | null;
+  api_key_set?: boolean;
+}
+
+export interface ProfileListResponse {
+  profiles: ProfileInfo[];
+}
+
+export interface ProfileDetailResponse {
+  name: string;
+  config: Record<string, unknown>;
+  api_key_set: boolean;
+}
+
+export interface ProfileMutationResponse {
+  name: string;
+  message: string;
+}
+
+export interface SaveProfileRequest {
+  llm: Record<string, unknown>;
+  include_secrets?: boolean;
+}
+
+export interface RenameProfileRequest {
+  new_name: string;
+}
+
+export type ExposeSecretsMode = 'encrypted' | 'plaintext';


### PR DESCRIPTION
- [ ] A human has tested these changes.

## Summary

- Add ProfilesClient mirroring the existing thin-client pattern (SettingsClient/SkillsClient): constructor takes { host, apiKey?, timeout? }, holds an HttpClient, and exposes close(). Methods cover the full /api/profiles surface: listProfiles, getProfile, saveProfile, deleteProfile, renameProfile, activateProfile. Path segments go through encodeURIComponent.
- Support the new X-Expose-Secrets header from agent-sdk #3161 via getProfile(name, { exposeSecrets }), where exposeSecrets is 'encrypted' | 'plaintext'. Header is omitted when not set, preserving the default nulled-api_key behavior.
- Add corresponding response/request types to models/api.ts (ProfileInfo, ProfileListResponse, ProfileDetailResponse, ProfileMutationResponse, ActivateProfileResponse, SaveProfileRequest, RenameProfileRequest, ExposeSecretsMode) and re-export from index.ts.
- Wire ProfilesClient into ConversationManager as manager.profiles, including close().
- Add RemoteConversation.switchLlm(llm) to fill a parity gap with the server's existing POST /api/conversations/{id}/switch_llm endpoint (sibling of the already-wired switchProfile).

## Missing — integration tests

This PR ships unit tests only (mocked `global.fetch`). Integration coverage in `src/__tests__/integration/` is not added here. Tracked in #149:

- Profiles CRUD round-trip against a real agent-server — endpoints exist on `main` and can be tested now.
- `switchLlm` line in `deterministic-api.integration.test.ts` next to the existing `switchProfile` 404 check.
- `X-Expose-Secrets: encrypted | plaintext` end-to-end — blocked on OpenHands/software-agent-sdk#3161 merging.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore