### PR TITLE
Fix npm audit security failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1202,9 +1202,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Refresh `package-lock.json` so `@babel/plugin-transform-modules-systemjs` resolves to patched version `7.29.4`.
- Fix the failing `security` CI job caused by GHSA-fv7c-fp4j-7gwp in `@babel/plugin-transform-modules-systemjs@7.29.0`.

## Verification
- `npm ci`
- `npm audit --audit-level=moderate`
- `git diff --check`

_This PR was created by an AI agent (OpenHands) on behalf of the user._
