### PR TITLE
Fix duplicate package publish workflow

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -1,9 +1,6 @@
-name: Publish to GitHub Packages
+name: Publish to GitHub Packages (Manual)
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       version:
@@ -18,80 +15,36 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20.x
-        cache: 'npm'
-        registry-url: 'https://npm.pkg.github.com'
-        scope: '@openhands'
-        
-    - name: Install dependencies
-      run: npm ci
-      
-    - name: Run tests
-      run: npm test
-      
-    - name: Build package
-      run: npm run build
-      
-    - name: Extract version from tag or input
-      id: version
-      run: |
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-        else
-          echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-        fi
-      
-    - name: Update package version
-      run: npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
-      
-    - name: Publish to GitHub Packages
-      run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Create GitHub Release (for tag pushes only)
-      if: github.event_name == 'push'
-      uses: softprops/action-gh-release@v1
-      with:
-        tag_name: ${{ github.ref_name }}
-        name: Release ${{ github.ref_name }}
-        draft: false
-        prerelease: false
-        generate_release_notes: true
-        body: |
-          ## Installation from GitHub Packages
-          
-          ```bash
-          npm install @openhands/typescript-client@${{ steps.version.outputs.VERSION }} --registry=https://npm.pkg.github.com
-          ```
-          
-          Or add to your `.npmrc`:
-          ```
-          @openhands:registry=https://npm.pkg.github.com
-          ```
-          
-          Then install normally:
-          ```bash
-          npm install @openhands/typescript-client@${{ steps.version.outputs.VERSION }}
-          ```
-          
-          ## Usage
-          
-          ```typescript
-          import { RemoteConversation } from '@openhands/typescript-client';
-          
-          const conversation = new RemoteConversation({
-            baseUrl: 'http://localhost:8000',
-            apiKey: 'your-api-key'
-          });
-          
-          await conversation.start();
-          ```
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@openhands'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+
+      - name: Extract version from input
+        id: version
+        run: echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+
+      - name: Update package version
+        run: npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
+
+      - name: Publish to GitHub Packages
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -15,17 +15,20 @@ The package is published exclusively to **GitHub Packages** for GitHub-native in
 ### Publishing Process
 
 1. **Create and push a version tag**:
+
    ```bash
    git tag v1.0.0
    git push origin v1.0.0
    ```
 
-2. **The GitHub Action will automatically**:
+2. **The `Release` GitHub Action will automatically**:
    - Run tests
    - Build the package
    - Update package.json version
    - Publish to GitHub Packages
    - Create a GitHub release with installation instructions
+
+Only `.github/workflows/release.yml` should run on version tags. The manual publish workflow is for explicit `workflow_dispatch` recovery only and must not also run on tag pushes, otherwise it can race the release workflow and fail with a duplicate-version conflict.
 
 ## Manual Publishing
 
@@ -41,16 +44,19 @@ The package is published exclusively to **GitHub Packages** for GitHub-native in
 ### Publishing Steps
 
 1. **Update version**:
+
    ```bash
    npm version patch  # or minor, major
    ```
 
 2. **Build the package**:
+
    ```bash
    npm run build
    ```
 
 3. **Run tests**:
+
    ```bash
    npm test
    ```
@@ -65,17 +71,21 @@ The package is published exclusively to **GitHub Packages** for GitHub-native in
 ### From GitHub Packages
 
 #### Option 1: Configure .npmrc (Recommended)
+
 Add to your `.npmrc` file:
+
 ```
 @openhands:registry=https://npm.pkg.github.com
 ```
 
 Then install:
+
 ```bash
 npm install @openhands/typescript-client
 ```
 
 #### Option 2: Direct install with registry flag
+
 ```bash
 npm install @openhands/typescript-client --registry=https://npm.pkg.github.com
 ```
@@ -89,17 +99,19 @@ npm install @openhands/typescript-client --registry=https://npm.pkg.github.com
 ### Version Conflicts
 
 If you encounter version conflicts, ensure:
+
 - The version in `package.json` matches the git tag
 - The version doesn't already exist in the registry
 
 ### Build Failures
 
 Common issues:
+
 - TypeScript compilation errors: Fix in source code
 - Test failures: Ensure all tests pass before publishing
 - Missing dependencies: Run `npm ci` to install exact versions
 
 ## Workflow Files
 
-- `.github/workflows/release.yml`: Main release workflow (GitHub Packages)
-- `.github/workflows/publish-github-packages.yml`: GitHub Packages only workflow with manual trigger
+- `.github/workflows/release.yml`: Main tag-triggered release workflow (GitHub Packages and GitHub Release)
+- `.github/workflows/publish-github-packages.yml`: Manual GitHub Packages recovery workflow (`workflow_dispatch` only)


### PR DESCRIPTION
## Summary
- make the secondary GitHub Packages publish workflow manual-only
- remove tag-push release creation from that manual recovery workflow
- document that `release.yml` is the only tag-triggered release workflow

## Validation
- `git diff --check`
- `npx prettier --check .github/workflows/publish-github-packages.yml PUBLISHING.md`

This PR was created by an AI agent (OpenHands) on behalf of the user.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/77d969c2-590c-4415-a369-ecf32af71558)