### PR TITLE
fix(events): stop throwing at module load for Node.js ESM consumers

### DIFF
--- a/src/__tests__/websocket-client-bootstrap.test.ts
+++ b/src/__tests__/websocket-client-bootstrap.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression tests for the WebSocket client module-load behaviour.
+ *
+ * Background: Prior to PR #156 both `events/websocket-client.ts` and
+ * `events/bash-websocket-client.ts` ran an `if (typeof window !== 'undefined')
+ * { ... } else { require('ws') }` block at module load. Because the package
+ * is published as ESM (`"type": "module"`), `require` is undefined at runtime,
+ * so the fallback threw "WebSocket implementation not available. Install ws
+ * package for Node.js environments." on import — breaking every Node.js ESM
+ * consumer, regardless of whether they ever opened a WebSocket.
+ *
+ * The default Jest environment is `testEnvironment: 'node'` running under
+ * CommonJS via ts-jest, so `require('ws')` *succeeded* in tests and hid the
+ * bug from CI. These tests explicitly remove `globalThis.WebSocket` and
+ * reload the modules in isolation so the regression cannot return.
+ */
+
+const MODULES = ['../events/websocket-client', '../events/bash-websocket-client'] as const;
+
+// `globalThis.WebSocket` is declared non-optional in the DOM lib, so `delete`
+// needs to go through a Record cast to satisfy TS' strict optional check.
+type GlobalRecord = Record<string, unknown>;
+
+const setGlobalWebSocket = (value: unknown): void => {
+  (globalThis as unknown as GlobalRecord).WebSocket = value;
+};
+
+const deleteGlobalWebSocket = (): void => {
+  delete (globalThis as unknown as GlobalRecord).WebSocket;
+};
+
+const withoutGlobalWebSocket = (fn: () => void): void => {
+  const g = globalThis as unknown as GlobalRecord;
+  const hadWebSocket = Object.prototype.hasOwnProperty.call(g, 'WebSocket');
+  const original = g.WebSocket;
+  deleteGlobalWebSocket();
+  try {
+    jest.isolateModules(fn);
+  } finally {
+    if (hadWebSocket) {
+      setGlobalWebSocket(original);
+    } else {
+      deleteGlobalWebSocket();
+    }
+  }
+};
+
+describe('WebSocket client module loading', () => {
+  describe.each(MODULES)('%s', (modulePath) => {
+    it('does not throw at module load when globalThis.WebSocket is undefined', () => {
+      expect(() => {
+        withoutGlobalWebSocket(() => {
+          // Simulate the real ESM-consumer environment where `require('ws')`
+          // is unavailable / throws. In Jest's default CJS runtime, the
+          // `ws` package resolves fine, which is why the old broken code
+          // (`try { require('ws') } catch { throw ... }`) accidentally
+          // passed under CI even though every real Node.js ESM consumer hit
+          // the throw. We force the require call to throw here so the test
+          // exercises the same code path the published package does.
+          jest.doMock('ws', () => {
+            throw new Error('ws is not available in this environment');
+          });
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          require(modulePath);
+        });
+      }).not.toThrow();
+    });
+  });
+
+  it('reports a clear error via onError when start() is called without globalThis.WebSocket', () => {
+    let captured: Error | undefined;
+
+    withoutGlobalWebSocket(() => {
+      // See the note above on `jest.doMock('ws', ...)` — we also block the
+      // `ws` fallback here so the regression test mirrors what real Node.js
+      // ESM consumers experience.
+      jest.doMock('ws', () => {
+        throw new Error('ws is not available in this environment');
+      });
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { WebSocketCallbackClient } = require('../events/websocket-client');
+      const client = new WebSocketCallbackClient({
+        host: 'http://example.com',
+        conversationId: 'conv-1',
+        callback: () => {},
+        onError: (err: Error) => {
+          captured = err;
+        },
+      });
+      try {
+        client.start();
+      } finally {
+        client.stop();
+      }
+    });
+
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured?.message).toMatch(/No WebSocket implementation found on globalThis/i);
+    // The old "Install ws package for Node.js environments." message must never
+    // come back — its return would signal a re-introduction of the require('ws')
+    // fallback or another module-load throw.
+    expect(captured?.message).not.toMatch(/Install ws package/i);
+  });
+
+  it('uses the WebSocket constructor available on globalThis when one is present', () => {
+    const g = globalThis as unknown as GlobalRecord;
+    const hadWebSocket = Object.prototype.hasOwnProperty.call(g, 'WebSocket');
+    const original = g.WebSocket;
+
+    const calls: string[] = [];
+    class FakeWebSocket {
+      onopen: (() => void) | null = null;
+      onmessage: ((event: { data: unknown }) => void) | null = null;
+      onclose: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      constructor(url: string) {
+        calls.push(url);
+      }
+      close(): void {}
+    }
+    setGlobalWebSocket(FakeWebSocket);
+
+    try {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { WebSocketCallbackClient } = require('../events/websocket-client');
+        const client = new WebSocketCallbackClient({
+          host: 'http://example.com',
+          conversationId: 'conv-xyz',
+          callback: () => {},
+          apiKey: 'secret-key',
+        });
+        try {
+          client.start();
+        } finally {
+          client.stop();
+        }
+      });
+    } finally {
+      if (hadWebSocket) {
+        setGlobalWebSocket(original);
+      } else {
+        deleteGlobalWebSocket();
+      }
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe('ws://example.com/sockets/events/conv-xyz?session_api_key=secret-key');
+  });
+});

--- a/src/events/bash-websocket-client.ts
+++ b/src/events/bash-websocket-client.ts
@@ -5,21 +5,12 @@
 import { BashEvent } from '../models/workspace';
 import { ErrorCallbackType } from './websocket-client';
 
-let WebSocketImpl: any;
-
-if (typeof window !== 'undefined' && window.WebSocket) {
-  WebSocketImpl = window.WebSocket;
-} else {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const ws = require('ws');
-    WebSocketImpl = ws;
-  } catch {
-    throw new Error(
-      'WebSocket implementation not available. Install ws package for Node.js environments.'
-    );
-  }
-}
+// See `websocket-client.ts` for why we rely on `globalThis.WebSocket` instead
+// of falling back to `require('ws')` — short version: this package is ESM,
+// `require` is undefined at runtime, and the fallback used to throw at module
+// load time for every Node.js consumer.
+const WebSocketImpl: typeof WebSocket | undefined = (globalThis as { WebSocket?: typeof WebSocket })
+  .WebSocket;
 
 export interface BashWebSocketClientOptions {
   host: string;
@@ -75,6 +66,13 @@ export class BashWebSocketClient {
 
   private connect(): void {
     try {
+      if (!WebSocketImpl) {
+        throw new Error(
+          'No WebSocket implementation found on globalThis. Provide one by polyfilling ' +
+            '`globalThis.WebSocket` (e.g. with the `ws` package) before opening a connection.'
+        );
+      }
+
       const url = new URL(this.host);
       const wsScheme = url.protocol === 'https:' ? 'wss:' : 'ws:';
       const wsUrl = `${wsScheme}//${url.host}${url.pathname.replace(/\/$/, '')}/sockets/bash-events`;

--- a/src/events/websocket-client.ts
+++ b/src/events/websocket-client.ts
@@ -4,24 +4,19 @@
 
 import { Event, ConversationCallbackType } from '../types/base';
 
-// Use native WebSocket in browser, ws library in Node.js
-let WebSocketImpl: any;
-
-if (typeof window !== 'undefined' && window.WebSocket) {
-  // Browser environment
-  WebSocketImpl = window.WebSocket;
-} else {
-  // Node.js environment
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const ws = require('ws');
-    WebSocketImpl = ws;
-  } catch {
-    throw new Error(
-      'WebSocket implementation not available. Install ws package for Node.js environments.'
-    );
-  }
-}
+// Use whatever WebSocket the runtime exposes on `globalThis`. This covers
+// browsers, Web Workers, and Node.js >= 22 (where WHATWG WebSocket is on by
+// default; Node 21 exposes it under `--experimental-websocket`).
+//
+// We intentionally do NOT fall back to `require('ws')` here. This package is
+// published as ESM (`"type": "module"`), so `require` is undefined at runtime
+// and the previous fallback always threw at module-load time — breaking
+// *every* Node.js ESM consumer of the library regardless of whether they ever
+// open a WebSocket. Callers on older Node.js without a global `WebSocket`
+// should install `ws` and assign it to `globalThis.WebSocket` before
+// importing this module.
+const WebSocketImpl: typeof WebSocket | undefined = (globalThis as { WebSocket?: typeof WebSocket })
+  .WebSocket;
 
 /**
  * Error callback type for reporting non-fatal errors.
@@ -84,6 +79,13 @@ export class WebSocketCallbackClient {
 
   private connect(): void {
     try {
+      if (!WebSocketImpl) {
+        throw new Error(
+          'No WebSocket implementation found on globalThis. Provide one by polyfilling ' +
+            '`globalThis.WebSocket` (e.g. with the `ws` package) before opening a connection.'
+        );
+      }
+
       // Convert HTTP URL to WebSocket URL
       const url = new URL(this.host);
       const wsScheme = url.protocol === 'https:' ? 'wss:' : 'ws:';


### PR DESCRIPTION
## Why

Every Node.js ESM consumer of this package currently crashes at module load with:

```
WebSocket implementation not available. Install ws package for Node.js environments.
```

…even when they never open a WebSocket. The cause is in `src/events/websocket-client.ts` (and the copy in `src/events/bash-websocket-client.ts`):

```ts
if (typeof window !== 'undefined' && window.WebSocket) {
  WebSocketImpl = window.WebSocket;
} else {
  try {
    const ws = require('ws');   // <- `require` is undefined in ESM scope
    WebSocketImpl = ws;
  } catch {
    throw new Error(
      'WebSocket implementation not available. Install ws package for Node.js environments.'
    );
  }
}
```

This package is published as ESM (`"type": "module"` in `package.json`), so `require` does not exist at runtime in Node.js. The `try` always throws a `ReferenceError`, the `catch` rethrows the misleading "Install ws" message, and the throw fires at *module load* — before any caller has a chance to opt out.

The broken logic itself dates back to commit `1735ae9` ("Fix WebSocket browser compatibility", Oct 30 2025) — copied later into `bash-websocket-client.ts` by #125 — but it stayed latent for months because Node.js's strict ESM resolver rejected the package earlier (extensionless relative imports). PR #132 fixed the resolver issue, which unmasked this throw and made it suddenly visible to all Node.js consumers.

## What

Replace the runtime if/else/`require`/throw with a simple lookup:

```ts
const WebSocketImpl: typeof WebSocket | undefined = (
  globalThis as { WebSocket?: typeof WebSocket }
).WebSocket;
```

That works in:

- Browsers (`globalThis.WebSocket`)
- Web Workers (`self.WebSocket` === `globalThis.WebSocket`)
- Node.js ≥ 22 (WHATWG `WebSocket` is on by default)
- Node.js 21 with `--experimental-websocket`

If no `WebSocket` is available, we now surface a clear, actionable error via the **existing `onError` callback** at `connect()` time instead of crashing at module load. Callers on older Node.js can polyfill `globalThis.WebSocket` with the `ws` package themselves before importing.

This is consistent with AGENTS.md's "browser-compatible by default" stance: we no longer reach for the Node-only `ws` package from library code at all.

## How to Test

- `npm run build`
- `npm test`
- In a Node.js ESM project: `import { ... } from '@openhands/typescript-client'` should no longer throw on import.

## Type

- [x] Bug fix

## Notes

- The `ws` and `@types/ws` dependencies are now unused by the source. I left them in `package.json` because removing them is a publishing concern (consumers may currently rely on the transitive install) and is best handled in a follow-up. Happy to drop them here if you'd prefer.
- This PR was created by an AI agent (OpenHands) on behalf of @rbren.
