### PR TITLE
fix(events): never throw at module load, defer error to connect()

### DIFF
--- a/src/__tests__/package-import.test.ts
+++ b/src/__tests__/package-import.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression tests for the package import surface.
+ *
+ * The package previously threw at module load whenever `ws` could not be
+ * required (which is every Node.js ESM consumer, because `require` is not
+ * defined in ESM). The throw lived inside `events/websocket-client.ts` and
+ * `events/bash-websocket-client.ts`, both of which are transitively imported
+ * by the package barrel via `RemoteConversation`. As a result, even a
+ * consumer that only wanted `RemoteWorkspace` would crash on the very first
+ * line:
+ *
+ *     import { RemoteWorkspace } from "@openhands/typescript-client";
+ *
+ * These tests pin the new behaviour: the WebSocket modules never throw at
+ * module load, and the "no WebSocket implementation" condition is reported
+ * via the existing `onError` callback only when `start()` is called.
+ *
+ * Implementation note: the default Jest runner is CommonJS, so plain
+ * `require('ws')` *succeeds* in tests and hides the bug. Each test below
+ * uses `jest.isolateModules` + `jest.doMock('ws', () => { throw ... })` so
+ * the module-load path is exercised against the same conditions a real
+ * Node.js ESM consumer hits.
+ */
+
+const WEBSOCKET_MODULES = [
+  '../events/websocket-client',
+  '../events/bash-websocket-client',
+] as const;
+
+const mockWsAsUnavailable = (): void => {
+  jest.doMock('ws', () => {
+    throw new Error('ws is not available in this environment');
+  });
+};
+
+describe('package imports do not crash when `ws` is unavailable', () => {
+  describe.each(WEBSOCKET_MODULES)('%s', (modulePath) => {
+    it('does not throw at module load', () => {
+      expect(() => {
+        jest.isolateModules(() => {
+          mockWsAsUnavailable();
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          require(modulePath);
+        });
+      }).not.toThrow();
+    });
+  });
+
+  it('importing the package barrel does not throw when `ws` is unavailable', () => {
+    // This is the exact failure agent-canvas hit:
+    //   import { RemoteWorkspace } from "@openhands/typescript-client";
+    // would crash because the barrel transitively loads the websocket modules.
+    expect(() => {
+      jest.isolateModules(() => {
+        mockWsAsUnavailable();
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const pkg = require('../index');
+        // Touch a non-WebSocket export to make sure nothing is lazy in a way
+        // that defers the throw past the import statement itself.
+        expect(pkg.RemoteWorkspace).toBeDefined();
+        expect(pkg.Agent).toBeDefined();
+        expect(pkg.RemoteConversation).toBeDefined();
+      });
+    }).not.toThrow();
+  });
+
+  it('constructing RemoteWorkspace does not require `ws`', () => {
+    expect(() => {
+      jest.isolateModules(() => {
+        mockWsAsUnavailable();
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { RemoteWorkspace } = require('../index');
+        new RemoteWorkspace({
+          host: 'https://agent.example.com',
+          workingDir: '/workspace',
+          apiKey: 'secret-key',
+        });
+      });
+    }).not.toThrow();
+  });
+
+  it('WebSocketCallbackClient.start() reports the missing implementation via onError instead of throwing', () => {
+    let captured: Error | undefined;
+
+    jest.isolateModules(() => {
+      mockWsAsUnavailable();
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { WebSocketCallbackClient } = require('../events/websocket-client');
+      const client = new WebSocketCallbackClient({
+        host: 'http://example.com',
+        conversationId: 'conv-1',
+        callback: () => {},
+        onError: (err: Error) => {
+          captured = err;
+        },
+      });
+      try {
+        client.start();
+      } finally {
+        client.stop();
+      }
+    });
+
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured?.message).toMatch(/WebSocket implementation not available/i);
+  });
+
+  it('BashWebSocketClient.start() reports the missing implementation via onError instead of throwing', () => {
+    let captured: Error | undefined;
+
+    jest.isolateModules(() => {
+      mockWsAsUnavailable();
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { BashWebSocketClient } = require('../events/bash-websocket-client');
+      const client = new BashWebSocketClient({
+        host: 'http://example.com',
+        callback: () => {},
+        onError: (err: Error) => {
+          captured = err;
+        },
+      });
+      try {
+        client.start();
+      } finally {
+        client.stop();
+      }
+    });
+
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured?.message).toMatch(/WebSocket implementation not available/i);
+  });
+});

--- a/src/events/bash-websocket-client.ts
+++ b/src/events/bash-websocket-client.ts
@@ -5,6 +5,10 @@
 import { BashEvent } from '../models/workspace';
 import { ErrorCallbackType } from './websocket-client';
 
+// IMPORTANT: this block must never throw. See the matching note in
+// `events/websocket-client.ts` — the "no WebSocket implementation"
+// condition is deferred to connect() time so importing this module does
+// not crash consumers that never use bash event streaming.
 let WebSocketImpl: any;
 
 if (typeof window !== 'undefined' && window.WebSocket) {
@@ -15,9 +19,7 @@ if (typeof window !== 'undefined' && window.WebSocket) {
     const ws = require('ws');
     WebSocketImpl = ws;
   } catch {
-    throw new Error(
-      'WebSocket implementation not available. Install ws package for Node.js environments.'
-    );
+    WebSocketImpl = undefined;
   }
 }
 
@@ -75,6 +77,12 @@ export class BashWebSocketClient {
 
   private connect(): void {
     try {
+      if (!WebSocketImpl) {
+        throw new Error(
+          'WebSocket implementation not available. Install the `ws` package, ' +
+            'or run in an environment with a global WebSocket constructor.'
+        );
+      }
       const url = new URL(this.host);
       const wsScheme = url.protocol === 'https:' ? 'wss:' : 'ws:';
       const wsUrl = `${wsScheme}//${url.host}${url.pathname.replace(/\/$/, '')}/sockets/bash-events`;

--- a/src/events/websocket-client.ts
+++ b/src/events/websocket-client.ts
@@ -4,7 +4,15 @@
 
 import { Event, ConversationCallbackType } from '../types/base';
 
-// Use native WebSocket in browser, ws library in Node.js
+// Use native WebSocket in browser, ws library in Node.js.
+//
+// IMPORTANT: this block must never throw. It runs whenever this file is
+// imported, and this file is transitively imported by the package barrel
+// (via RemoteConversation), so any throw here crashes consumers that
+// merely `import { RemoteWorkspace } from "@openhands/typescript-client"`
+// even when they have no intent to open a WebSocket. The "no implementation
+// available" condition is deferred to connect() time, where it is surfaced
+// through the existing onError callback channel.
 let WebSocketImpl: any;
 
 if (typeof window !== 'undefined' && window.WebSocket) {
@@ -17,9 +25,8 @@ if (typeof window !== 'undefined' && window.WebSocket) {
     const ws = require('ws');
     WebSocketImpl = ws;
   } catch {
-    throw new Error(
-      'WebSocket implementation not available. Install ws package for Node.js environments.'
-    );
+    // Leave WebSocketImpl undefined; connect() reports the error via onError.
+    WebSocketImpl = undefined;
   }
 }
 
@@ -84,6 +91,12 @@ export class WebSocketCallbackClient {
 
   private connect(): void {
     try {
+      if (!WebSocketImpl) {
+        throw new Error(
+          'WebSocket implementation not available. Install the `ws` package, ' +
+            'or run in an environment with a global WebSocket constructor.'
+        );
+      }
       // Convert HTTP URL to WebSocket URL
       const url = new URL(this.host);
       const wsScheme = url.protocol === 'https:' ? 'wss:' : 'ws:';


### PR DESCRIPTION
## Problem

Importing anything from `@openhands/typescript-client` transitively loads `events/websocket-client.ts` (via `RemoteConversation` re-exported from the barrel). That file runs a `require('ws')` fallback at **module-load time** and throws

> WebSocket implementation not available. Install ws package for Node.js environments.

whenever the require fails. In a Node.js ESM consumer `require` is undefined, so the fallback always throws — meaning a consumer like agent-canvas can't even do

```ts
import { RemoteWorkspace } from "@openhands/typescript-client";
```

without crashing, despite never opening a WebSocket. The same buggy block was copied into `bash-websocket-client.ts`.

## Fix

Stop throwing at module load. Set `WebSocketImpl = undefined` in the catch instead, and surface the missing-implementation error through the existing `onError` callback the first time `connect()` is actually called — exactly the same channel every other WebSocket connection error already flows through. Consumers that never open a WebSocket pay nothing.

This is the minimum surgical change needed to make the package importable; the `if (typeof window …) else require('ws')` runtime detection itself is untouched.

```diff
-} catch {
-  throw new Error(
-    'WebSocket implementation not available. Install ws package for Node.js environments.'
-  );
-}
+} catch {
+  // Leave WebSocketImpl undefined; connect() reports the error via onError.
+  WebSocketImpl = undefined;
+}
```

```diff
 private connect(): void {
   try {
+    if (!WebSocketImpl) {
+      throw new Error(
+        'WebSocket implementation not available. Install the `ws` package, ' +
+          'or run in an environment with a global WebSocket constructor.'
+      );
+    }
     // …
```

The existing `try { … } catch (error) { this.reportError(...); if (this.shouldReconnect) this.scheduleReconnect(); }` wrapper already handles this — it just was unreachable before because the module-load throw fired first.

## Regression test

New `src/__tests__/package-import.test.ts` covers:

* Importing each websocket module directly does not throw when `ws` is unavailable.
* **`require('../index')` does not throw** and exposes `RemoteWorkspace`, `Agent`, `RemoteConversation` — the exact import shape agent-canvas uses.
* Constructing `RemoteWorkspace` with no `ws` available does not throw.
* `WebSocketCallbackClient.start()` and `BashWebSocketClient.start()` surface the missing-implementation error via `onError` instead of throwing.

All tests use `jest.isolateModules` + `jest.doMock('ws', () => { throw … })`. This is critical: Jest's default runner is CommonJS, so a plain `require('ws')` *succeeds* in tests — which is exactly why this regression slipped past CI for months even though every real Node.js ESM consumer crashed on import.

Verified the tests fail on the pre-fix code (all 6 throw with the legacy `"Install ws package..."` message) and pass after the fix. Full suite: 193/193.

## Why not also switch to `globalThis.WebSocket`?

Modern Node 22+, Bun and edge runtimes all expose `globalThis.WebSocket` with no need for the `ws` package, and a future PR could pick that up via a `globalThis.WebSocket` lookup. That's a behaviour change worth shipping separately; this PR is intentionally limited to "don't crash on import".

---

_This PR was created by an AI agent (OpenHands) on behalf of @rbren._
