### PR TITLE
feat(settings): mirror Python SDK's ACP_PROVIDERS registry

### DIFF
--- a/src/__tests__/acp-providers.test.ts
+++ b/src/__tests__/acp-providers.test.ts
@@ -1,0 +1,137 @@
+import {
+  ACP_PROVIDERS,
+  getACPProvider,
+  detectACPProviderByAgentName,
+  buildSessionModelMeta,
+} from '../index';
+import type { ACPProviderInfo, ACPServerKind } from '../index';
+
+describe('ACP_PROVIDERS', () => {
+  it('exposes the three built-in providers in stable order', () => {
+    expect(Object.keys(ACP_PROVIDERS)).toEqual([
+      'claude-code',
+      'codex',
+      'gemini-cli',
+    ]);
+  });
+
+  it('uses the package names the SDK ships with — drift here breaks real spawns', () => {
+    // These are the only invocations that actually start an ACP server in the
+    // current ecosystem; the npm packages that look related but ARE NOT
+    // ACP servers (e.g. `@openai/codex acp` which is interactive-only) used
+    // to leak into this registry and silently deadlocked the agent loop.
+    expect(ACP_PROVIDERS['claude-code'].defaultCommand).toEqual([
+      'npx',
+      '-y',
+      '@agentclientprotocol/claude-agent-acp',
+    ]);
+    expect(ACP_PROVIDERS['codex'].defaultCommand).toEqual([
+      'npx',
+      '-y',
+      '@zed-industries/codex-acp',
+    ]);
+    expect(ACP_PROVIDERS['gemini-cli'].defaultCommand).toEqual([
+      'npx',
+      '-y',
+      '@google/gemini-cli',
+      '--acp',
+    ]);
+  });
+
+  it('pairs each provider with its API-key + base-URL env vars', () => {
+    expect(ACP_PROVIDERS['claude-code'].apiKeyEnvVar).toBe('ANTHROPIC_API_KEY');
+    expect(ACP_PROVIDERS['claude-code'].baseUrlEnvVar).toBe(
+      'ANTHROPIC_BASE_URL',
+    );
+    expect(ACP_PROVIDERS['codex'].apiKeyEnvVar).toBe('OPENAI_API_KEY');
+    expect(ACP_PROVIDERS['codex'].baseUrlEnvVar).toBe('OPENAI_BASE_URL');
+    expect(ACP_PROVIDERS['gemini-cli'].apiKeyEnvVar).toBe('GEMINI_API_KEY');
+    expect(ACP_PROVIDERS['gemini-cli'].baseUrlEnvVar).toBe('GEMINI_BASE_URL');
+  });
+
+  it('declares the right session-mode + model-selection protocol per provider', () => {
+    // claude-agent-acp selects models via session _meta, not set_session_model
+    expect(ACP_PROVIDERS['claude-code'].supportsSetSessionModel).toBe(false);
+    expect(ACP_PROVIDERS['claude-code'].sessionMetaKey).toBe('claudeCode');
+    expect(ACP_PROVIDERS['claude-code'].defaultSessionMode).toBe(
+      'bypassPermissions',
+    );
+
+    // codex-acp + gemini-cli select via set_session_model
+    expect(ACP_PROVIDERS['codex'].supportsSetSessionModel).toBe(true);
+    expect(ACP_PROVIDERS['codex'].sessionMetaKey).toBeNull();
+    expect(ACP_PROVIDERS['codex'].defaultSessionMode).toBe('full-access');
+
+    expect(ACP_PROVIDERS['gemini-cli'].supportsSetSessionModel).toBe(true);
+    expect(ACP_PROVIDERS['gemini-cli'].sessionMetaKey).toBeNull();
+    expect(ACP_PROVIDERS['gemini-cli'].defaultSessionMode).toBe('yolo');
+  });
+
+  it('is frozen — callers cannot mutate the registry by accident', () => {
+    expect(Object.isFrozen(ACP_PROVIDERS)).toBe(true);
+    expect(Object.isFrozen(ACP_PROVIDERS['codex'])).toBe(true);
+    expect(Object.isFrozen(ACP_PROVIDERS['codex'].defaultCommand)).toBe(true);
+  });
+});
+
+describe('getACPProvider', () => {
+  it('returns the matching provider info for a known key', () => {
+    const info = getACPProvider('claude-code');
+    expect(info?.displayName).toBe('Claude Code');
+  });
+
+  it('returns undefined for an unknown key', () => {
+    expect(getACPProvider('definitely-not-a-provider')).toBeUndefined();
+    // ``custom`` is a discriminator value but intentionally NOT in the
+    // registry — the user supplies their own ``acp_command``.
+    expect(getACPProvider('custom')).toBeUndefined();
+  });
+
+  it('accepts an ACPServerKind without a type assertion', () => {
+    const kind: ACPServerKind = 'codex';
+    const info: ACPProviderInfo | undefined = getACPProvider(kind);
+    expect(info?.key).toBe('codex');
+  });
+});
+
+describe('detectACPProviderByAgentName', () => {
+  it('matches by lowercased substring of the runtime agent_name', () => {
+    expect(detectACPProviderByAgentName('claude-agent-acp')?.key).toBe(
+      'claude-code',
+    );
+    expect(detectACPProviderByAgentName('Claude-Agent-ACP')?.key).toBe(
+      'claude-code',
+    );
+    expect(detectACPProviderByAgentName('codex-acp')?.key).toBe('codex');
+    expect(detectACPProviderByAgentName('gemini-cli')?.key).toBe('gemini-cli');
+  });
+
+  it('returns undefined when no pattern matches', () => {
+    expect(detectACPProviderByAgentName('some-custom-agent')).toBeUndefined();
+  });
+});
+
+describe('buildSessionModelMeta', () => {
+  it('returns a _meta block for providers with a session_meta_key', () => {
+    expect(
+      buildSessionModelMeta('claude-agent-acp', 'claude-opus-4-5'),
+    ).toEqual({
+      claudeCode: { options: { model: 'claude-opus-4-5' } },
+    });
+  });
+
+  it('returns an empty object when the provider uses set_session_model', () => {
+    expect(buildSessionModelMeta('codex-acp', 'gpt-5.4')).toEqual({});
+    expect(buildSessionModelMeta('gemini-cli', 'gemini-2.0-pro')).toEqual({});
+  });
+
+  it('returns an empty object when acp_model is null/empty', () => {
+    expect(buildSessionModelMeta('claude-agent-acp', null)).toEqual({});
+    expect(buildSessionModelMeta('claude-agent-acp', undefined)).toEqual({});
+    expect(buildSessionModelMeta('claude-agent-acp', '')).toEqual({});
+  });
+
+  it('returns an empty object when the agent name is unrecognised', () => {
+    expect(buildSessionModelMeta('some-unknown-agent', 'model')).toEqual({});
+  });
+});

--- a/src/__tests__/acp-providers.test.ts
+++ b/src/__tests__/acp-providers.test.ts
@@ -8,11 +8,7 @@ import type { ACPProviderInfo, ACPServerKind } from '../index';
 
 describe('ACP_PROVIDERS', () => {
   it('exposes the three built-in providers in stable order', () => {
-    expect(Object.keys(ACP_PROVIDERS)).toEqual([
-      'claude-code',
-      'codex',
-      'gemini-cli',
-    ]);
+    expect(Object.keys(ACP_PROVIDERS)).toEqual(['claude-code', 'codex', 'gemini-cli']);
   });
 
   it('uses the package names the SDK ships with — drift here breaks real spawns', () => {
@@ -40,9 +36,7 @@ describe('ACP_PROVIDERS', () => {
 
   it('pairs each provider with its API-key + base-URL env vars', () => {
     expect(ACP_PROVIDERS['claude-code'].apiKeyEnvVar).toBe('ANTHROPIC_API_KEY');
-    expect(ACP_PROVIDERS['claude-code'].baseUrlEnvVar).toBe(
-      'ANTHROPIC_BASE_URL',
-    );
+    expect(ACP_PROVIDERS['claude-code'].baseUrlEnvVar).toBe('ANTHROPIC_BASE_URL');
     expect(ACP_PROVIDERS['codex'].apiKeyEnvVar).toBe('OPENAI_API_KEY');
     expect(ACP_PROVIDERS['codex'].baseUrlEnvVar).toBe('OPENAI_BASE_URL');
     expect(ACP_PROVIDERS['gemini-cli'].apiKeyEnvVar).toBe('GEMINI_API_KEY');
@@ -53,9 +47,7 @@ describe('ACP_PROVIDERS', () => {
     // claude-agent-acp selects models via session _meta, not set_session_model
     expect(ACP_PROVIDERS['claude-code'].supportsSetSessionModel).toBe(false);
     expect(ACP_PROVIDERS['claude-code'].sessionMetaKey).toBe('claudeCode');
-    expect(ACP_PROVIDERS['claude-code'].defaultSessionMode).toBe(
-      'bypassPermissions',
-    );
+    expect(ACP_PROVIDERS['claude-code'].defaultSessionMode).toBe('bypassPermissions');
 
     // codex-acp + gemini-cli select via set_session_model
     expect(ACP_PROVIDERS['codex'].supportsSetSessionModel).toBe(true);
@@ -96,12 +88,8 @@ describe('getACPProvider', () => {
 
 describe('detectACPProviderByAgentName', () => {
   it('matches by lowercased substring of the runtime agent_name', () => {
-    expect(detectACPProviderByAgentName('claude-agent-acp')?.key).toBe(
-      'claude-code',
-    );
-    expect(detectACPProviderByAgentName('Claude-Agent-ACP')?.key).toBe(
-      'claude-code',
-    );
+    expect(detectACPProviderByAgentName('claude-agent-acp')?.key).toBe('claude-code');
+    expect(detectACPProviderByAgentName('Claude-Agent-ACP')?.key).toBe('claude-code');
     expect(detectACPProviderByAgentName('codex-acp')?.key).toBe('codex');
     expect(detectACPProviderByAgentName('gemini-cli')?.key).toBe('gemini-cli');
   });
@@ -113,9 +101,7 @@ describe('detectACPProviderByAgentName', () => {
 
 describe('buildSessionModelMeta', () => {
   it('returns a _meta block for providers with a session_meta_key', () => {
-    expect(
-      buildSessionModelMeta('claude-agent-acp', 'claude-opus-4-5'),
-    ).toEqual({
+    expect(buildSessionModelMeta('claude-agent-acp', 'claude-opus-4-5')).toEqual({
       claudeCode: { options: { model: 'claude-opus-4-5' } },
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,16 @@ export {
 } from './hooks';
 export type { HookEvent, HookResult, HookDefinition, HookMatcher, HookConfig } from './hooks';
 
+// Settings — built-in ACP provider registry (mirrors the Python SDK's
+// ``openhands.sdk.settings.acp_providers``).
+export {
+  ACP_PROVIDERS,
+  getACPProvider,
+  detectACPProviderByAgentName,
+  buildSessionModelMeta,
+} from './settings/acp-providers';
+export type { ACPServerKind, ACPProviderInfo } from './settings/acp-providers';
+
 // Agent classes
 export { Agent } from './agent/agent';
 
@@ -366,6 +376,12 @@ import {
   mergeHookConfigs,
   hookConfigToJSON,
 } from './hooks';
+import {
+  ACP_PROVIDERS,
+  getACPProvider,
+  detectACPProviderByAgentName,
+  buildSessionModelMeta,
+} from './settings/acp-providers';
 
 // Default export for convenience
 export default {
@@ -410,4 +426,8 @@ export default {
   hasHooksForEvent,
   mergeHookConfigs,
   hookConfigToJSON,
+  ACP_PROVIDERS,
+  getACPProvider,
+  detectACPProviderByAgentName,
+  buildSessionModelMeta,
 };

--- a/src/settings/acp-providers.ts
+++ b/src/settings/acp-providers.ts
@@ -1,0 +1,194 @@
+/**
+ * ACP provider registry — TypeScript mirror of the Python SDK's
+ * ``openhands.sdk.settings.acp_providers`` module. The Python module is the
+ * source of truth; this file is hand-kept in sync.
+ *
+ * Each record captures the static properties known at configuration time
+ * (before any subprocess is launched):
+ *
+ * - ``key``                   settings discriminator (``ACPAgentConfig.acp_server``)
+ * - ``displayName``           human-readable label for UI display
+ * - ``defaultCommand``        default ``npx``-based launch command
+ * - ``apiKeyEnvVar``          env var the subprocess expects for its API key
+ * - ``baseUrlEnvVar``         env var for proxy/base-URL routing (or ``null``)
+ * - ``defaultSessionMode``    ACP mode ID that disables permission prompts
+ * - ``agentNamePatterns``     lowercase substrings in the runtime agent name;
+ *                             used to auto-detect mode / protocol
+ * - ``supportsSetSessionModel``  whether to use the ``set_session_model``
+ *                                protocol call (vs ``_meta``) for model selection
+ * - ``sessionMetaKey``        top-level ``_meta`` key for model selection, or null
+ */
+
+/** Settings discriminator value for the four built-in ``acp_server`` choices. */
+export type ACPServerKind = 'claude-code' | 'codex' | 'gemini-cli' | 'custom';
+
+/** Immutable metadata record for one built-in ACP provider. */
+export interface ACPProviderInfo {
+  /** Settings discriminator value (``ACPAgentConfig.acp_server``). */
+  readonly key: string;
+  /** Human-readable name suitable for UI labels. */
+  readonly displayName: string;
+  /** Default subprocess command used when no explicit ``acp_command`` is set. */
+  readonly defaultCommand: readonly string[];
+  /**
+   * Env var the ACP subprocess expects for its primary API credential.
+   *
+   * ``null`` for providers that authenticate via browser login rather than
+   * an API key (e.g. Claude Code's ``claude-login`` flow).
+   */
+  readonly apiKeyEnvVar: string | null;
+  /**
+   * Env var the ACP subprocess reads for a custom API base URL.
+   *
+   * Allows routing provider calls through a proxy such as LiteLLM.
+   * ``null`` if the provider does not support env-based base-URL override.
+   */
+  readonly baseUrlEnvVar: string | null;
+  /**
+   * ACP session-mode ID that suppresses all permission prompts.
+   *
+   * Different servers use different IDs for the same concept:
+   *
+   * - ``bypassPermissions`` — claude-agent-acp
+   * - ``full-access``       — codex-acp
+   * - ``yolo``              — gemini-cli
+   */
+  readonly defaultSessionMode: string;
+  /**
+   * Lowercase substring fragments present in the runtime ``agent_name``.
+   *
+   * ``ACPAgent`` checks these against the name returned by the ACP server's
+   * ``InitializeResponse`` to auto-select the correct session mode and
+   * determine which model-selection protocol to use.
+   */
+  readonly agentNamePatterns: readonly string[];
+  /**
+   * ``true`` if this provider uses the ``set_session_model`` protocol call.
+   *
+   * - ``false`` for claude-agent-acp, which uses session ``_meta`` instead.
+   * - ``true``  for codex-acp and gemini-cli.
+   */
+  readonly supportsSetSessionModel: boolean;
+  /**
+   * Top-level ``_meta`` key for model selection, or ``null``.
+   *
+   * When non-null, the provider selects its model via ACP session ``_meta``
+   * using the structure ``{[sessionMetaKey]: {options: {model: <model>}}}``.
+   * ``null`` means the provider uses the ``set_session_model`` protocol call
+   * instead (see {@link supportsSetSessionModel}).
+   *
+   * - ``"claudeCode"`` — claude-agent-acp
+   * - ``null``         — codex-acp, gemini-cli
+   */
+  readonly sessionMetaKey: string | null;
+}
+
+/**
+ * Read-only registry of built-in ACP providers keyed by ``acp_server`` value.
+ *
+ * Insertion order matches the Python SDK so consumers that render the
+ * providers in a UI dropdown get the same default ordering. Note that this
+ * registry intentionally omits the ``"custom"`` discriminator — that key
+ * means *the user supplies the raw ``acp_command``*, so there is no static
+ * metadata to track.
+ */
+export const ACP_PROVIDERS: Readonly<Record<string, ACPProviderInfo>> =
+  Object.freeze({
+    'claude-code': Object.freeze({
+      key: 'claude-code',
+      displayName: 'Claude Code',
+      defaultCommand: Object.freeze([
+        'npx',
+        '-y',
+        '@agentclientprotocol/claude-agent-acp',
+      ]),
+      apiKeyEnvVar: 'ANTHROPIC_API_KEY',
+      baseUrlEnvVar: 'ANTHROPIC_BASE_URL',
+      defaultSessionMode: 'bypassPermissions',
+      agentNamePatterns: Object.freeze(['claude-agent']),
+      supportsSetSessionModel: false,
+      sessionMetaKey: 'claudeCode',
+    }),
+    codex: Object.freeze({
+      key: 'codex',
+      displayName: 'Codex',
+      defaultCommand: Object.freeze([
+        'npx',
+        '-y',
+        '@zed-industries/codex-acp',
+      ]),
+      apiKeyEnvVar: 'OPENAI_API_KEY',
+      baseUrlEnvVar: 'OPENAI_BASE_URL',
+      defaultSessionMode: 'full-access',
+      agentNamePatterns: Object.freeze(['codex-acp']),
+      supportsSetSessionModel: true,
+      sessionMetaKey: null,
+    }),
+    'gemini-cli': Object.freeze({
+      key: 'gemini-cli',
+      displayName: 'Gemini CLI',
+      defaultCommand: Object.freeze([
+        'npx',
+        '-y',
+        '@google/gemini-cli',
+        '--acp',
+      ]),
+      apiKeyEnvVar: 'GEMINI_API_KEY',
+      baseUrlEnvVar: 'GEMINI_BASE_URL',
+      defaultSessionMode: 'yolo',
+      agentNamePatterns: Object.freeze(['gemini-cli']),
+      supportsSetSessionModel: true,
+      sessionMetaKey: null,
+    }),
+  });
+
+/** Return the {@link ACPProviderInfo} for ``key``, or ``undefined`` if unknown. */
+export function getACPProvider(key: string): ACPProviderInfo | undefined {
+  return ACP_PROVIDERS[key];
+}
+
+/**
+ * Identify a provider from the runtime ``agent_name`` string.
+ *
+ * Iterates {@link ACP_PROVIDERS} in insertion order and returns the first
+ * entry whose {@link ACPProviderInfo.agentNamePatterns} contains a
+ * substring of ``agentName.toLowerCase()``.
+ *
+ * Returns ``undefined`` when no pattern matches (e.g. a ``'custom'`` server
+ * or an unrecognised third-party ACP implementation).
+ */
+export function detectACPProviderByAgentName(
+  agentName: string,
+): ACPProviderInfo | undefined {
+  const lower = agentName.toLowerCase();
+  for (const info of Object.values(ACP_PROVIDERS)) {
+    if (info.agentNamePatterns.some((pat) => lower.includes(pat))) {
+      return info;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build ACP session ``_meta`` content for model selection.
+ *
+ * Returns the object to spread into ``newSession()`` kwargs for providers
+ * that select their model via ``_meta`` (i.e. those whose
+ * {@link ACPProviderInfo.sessionMetaKey} is non-null).
+ *
+ * Returns an empty object when *acpModel* is null/undefined or when the
+ * detected provider uses the ``set_session_model`` protocol call instead.
+ */
+export function buildSessionModelMeta(
+  agentName: string,
+  acpModel: string | null | undefined,
+): Record<string, unknown> {
+  if (!acpModel) return {};
+  const provider = detectACPProviderByAgentName(agentName);
+  if (provider === undefined || provider.sessionMetaKey === null) {
+    return {};
+  }
+  return {
+    [provider.sessionMetaKey]: { options: { model: acpModel } },
+  };
+}

--- a/src/settings/acp-providers.ts
+++ b/src/settings/acp-providers.ts
@@ -92,55 +92,41 @@ export interface ACPProviderInfo {
  * means *the user supplies the raw ``acp_command``*, so there is no static
  * metadata to track.
  */
-export const ACP_PROVIDERS: Readonly<Record<string, ACPProviderInfo>> =
-  Object.freeze({
-    'claude-code': Object.freeze({
-      key: 'claude-code',
-      displayName: 'Claude Code',
-      defaultCommand: Object.freeze([
-        'npx',
-        '-y',
-        '@agentclientprotocol/claude-agent-acp',
-      ]),
-      apiKeyEnvVar: 'ANTHROPIC_API_KEY',
-      baseUrlEnvVar: 'ANTHROPIC_BASE_URL',
-      defaultSessionMode: 'bypassPermissions',
-      agentNamePatterns: Object.freeze(['claude-agent']),
-      supportsSetSessionModel: false,
-      sessionMetaKey: 'claudeCode',
-    }),
-    codex: Object.freeze({
-      key: 'codex',
-      displayName: 'Codex',
-      defaultCommand: Object.freeze([
-        'npx',
-        '-y',
-        '@zed-industries/codex-acp',
-      ]),
-      apiKeyEnvVar: 'OPENAI_API_KEY',
-      baseUrlEnvVar: 'OPENAI_BASE_URL',
-      defaultSessionMode: 'full-access',
-      agentNamePatterns: Object.freeze(['codex-acp']),
-      supportsSetSessionModel: true,
-      sessionMetaKey: null,
-    }),
-    'gemini-cli': Object.freeze({
-      key: 'gemini-cli',
-      displayName: 'Gemini CLI',
-      defaultCommand: Object.freeze([
-        'npx',
-        '-y',
-        '@google/gemini-cli',
-        '--acp',
-      ]),
-      apiKeyEnvVar: 'GEMINI_API_KEY',
-      baseUrlEnvVar: 'GEMINI_BASE_URL',
-      defaultSessionMode: 'yolo',
-      agentNamePatterns: Object.freeze(['gemini-cli']),
-      supportsSetSessionModel: true,
-      sessionMetaKey: null,
-    }),
-  });
+export const ACP_PROVIDERS: Readonly<Record<string, ACPProviderInfo>> = Object.freeze({
+  'claude-code': Object.freeze({
+    key: 'claude-code',
+    displayName: 'Claude Code',
+    defaultCommand: Object.freeze(['npx', '-y', '@agentclientprotocol/claude-agent-acp']),
+    apiKeyEnvVar: 'ANTHROPIC_API_KEY',
+    baseUrlEnvVar: 'ANTHROPIC_BASE_URL',
+    defaultSessionMode: 'bypassPermissions',
+    agentNamePatterns: Object.freeze(['claude-agent']),
+    supportsSetSessionModel: false,
+    sessionMetaKey: 'claudeCode',
+  }),
+  codex: Object.freeze({
+    key: 'codex',
+    displayName: 'Codex',
+    defaultCommand: Object.freeze(['npx', '-y', '@zed-industries/codex-acp']),
+    apiKeyEnvVar: 'OPENAI_API_KEY',
+    baseUrlEnvVar: 'OPENAI_BASE_URL',
+    defaultSessionMode: 'full-access',
+    agentNamePatterns: Object.freeze(['codex-acp']),
+    supportsSetSessionModel: true,
+    sessionMetaKey: null,
+  }),
+  'gemini-cli': Object.freeze({
+    key: 'gemini-cli',
+    displayName: 'Gemini CLI',
+    defaultCommand: Object.freeze(['npx', '-y', '@google/gemini-cli', '--acp']),
+    apiKeyEnvVar: 'GEMINI_API_KEY',
+    baseUrlEnvVar: 'GEMINI_BASE_URL',
+    defaultSessionMode: 'yolo',
+    agentNamePatterns: Object.freeze(['gemini-cli']),
+    supportsSetSessionModel: true,
+    sessionMetaKey: null,
+  }),
+});
 
 /** Return the {@link ACPProviderInfo} for ``key``, or ``undefined`` if unknown. */
 export function getACPProvider(key: string): ACPProviderInfo | undefined {
@@ -157,9 +143,7 @@ export function getACPProvider(key: string): ACPProviderInfo | undefined {
  * Returns ``undefined`` when no pattern matches (e.g. a ``'custom'`` server
  * or an unrecognised third-party ACP implementation).
  */
-export function detectACPProviderByAgentName(
-  agentName: string,
-): ACPProviderInfo | undefined {
+export function detectACPProviderByAgentName(agentName: string): ACPProviderInfo | undefined {
   const lower = agentName.toLowerCase();
   for (const info of Object.values(ACP_PROVIDERS)) {
     if (info.agentNamePatterns.some((pat) => lower.includes(pat))) {
@@ -181,7 +165,7 @@ export function detectACPProviderByAgentName(
  */
 export function buildSessionModelMeta(
   agentName: string,
-  acpModel: string | null | undefined,
+  acpModel: string | null | undefined
 ): Record<string, unknown> {
   if (!acpModel) return {};
   const provider = detectACPProviderByAgentName(agentName);


### PR DESCRIPTION
## Summary

Ports `openhands.sdk.settings.acp_providers` to TypeScript so downstream consumers (agent-canvas, OpenHands frontend) can resolve provider metadata — default command, display name, API-key env var, session mode, model-selection protocol — from a single source instead of maintaining their own copies and drifting out of sync.

The Python module remains the source of truth; this file is hand-kept in sync, with the same key set (`claude-code` / `codex` / `gemini-cli`) and the same default commands shipped with v1.22.1 of the SDK:

| Key          | Command                                              |
| ------------ | ---------------------------------------------------- |
| `claude-code`| `npx -y @agentclientprotocol/claude-agent-acp`       |
| `codex`      | `npx -y @zed-industries/codex-acp`                   |
| `gemini-cli` | `npx -y @google/gemini-cli --acp`                    |

### Motivating bug

A downstream consumer (OpenHands/agent-canvas#416) shipped its own copy of this registry and encoded `codex` as `npx -y @openai/codex acp`. That is **not** a valid ACP server: the codex CLI has no `acp` subcommand, so it treats `acp` as an interactive prompt and exits with `Error: stdin is not a terminal`. The agent-server's stdin-based ACP handshake then deadlocks forever, with no log line indicating what went wrong.

Centralizing the registry here prevents that class of bug — the test below asserts the package names explicitly so any future regression is caught at SDK CI time.

## API surface

```ts
import {
  ACP_PROVIDERS,
  getACPProvider,
  detectACPProviderByAgentName,
  buildSessionModelMeta,
  type ACPServerKind,
  type ACPProviderInfo,
} from "@openhands/typescript-client";
```

- `ACP_PROVIDERS` — frozen `Record<string, ACPProviderInfo>` (the registry itself + each value + each `defaultCommand` array are `Object.freeze`'d)
- `ACPServerKind` — literal union `'claude-code' | 'codex' | 'gemini-cli' | 'custom'`
- `ACPProviderInfo` — record interface (`key`, `displayName`, `defaultCommand`, `apiKeyEnvVar`, `baseUrlEnvVar`, `defaultSessionMode`, `agentNamePatterns`, `supportsSetSessionModel`, `sessionMetaKey`)
- `getACPProvider(key)` — registry lookup; `undefined` for unknown keys
- `detectACPProviderByAgentName(name)` — runtime-name → provider (matches `agentNamePatterns` against `name.toLowerCase()`)
- `buildSessionModelMeta(name, model)` — produces the `_meta` block for providers that select their model via session meta rather than `set_session_model`

## Tests

14 new unit tests in `src/__tests__/acp-providers.test.ts` cover:

- Registry contents — explicit package-name assertions (anti-drift guard)
- Env-var mapping per provider
- Session-mode + model-selection protocol per provider
- Registry + entry + `defaultCommand` immutability
- `getACPProvider` happy + missing-key paths (incl. `'custom'` deliberately omitted)
- `detectACPProviderByAgentName` case-insensitive substring matching + `undefined` fallback
- `buildSessionModelMeta` returns `_meta` for claude-code, empty for codex/gemini, empty for null/empty model, empty for unknown agent names

Full suite: `npm test` → 13 files / 213 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)