### PR TITLE
ci: add 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     reviewers:
       - "All-Hands-AI/core-team"


### PR DESCRIPTION
## Summary
- add a 7-day Dependabot cooldown for npm version updates
- avoid adopting brand-new package releases before they have had time to age
- keep the rest of the update policy intentionally simple

## Testing
- not run (configuration-only change)

_This PR was created by an AI agent (OpenHands) on behalf of the user._