### PR TITLE
fix(ci): clear two moderate npm audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3527,19 +3527,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -5664,6 +5651,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -7241,9 +7241,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
   },
   "overrides": {
     "eslint": {
-      "minimatch": "^10.2.1"
+      "minimatch": {
+        ".": "^10.2.1",
+        "brace-expansion": "^5.0.6"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

The `security` CI job (which runs `npm audit --audit-level=moderate`) has been failing on `main` for several PRs because two transitive advisories landed since the last green run:

1. **`brace-expansion 5.0.2 - 5.0.5`** — `GHSA-jxxr-4gwj-5jf2` (moderate; DoS via large numeric range that defeats the documented `max` protection). Reaches us via `eslint → minimatch@^10 → brace-expansion`. Fix: nest a `brace-expansion: ^5.0.6` override under the existing `eslint.minimatch` entry, so the pin only applies to the minimatch instance pulled in by eslint and leaves unrelated brace-expansion instances elsewhere in the tree (e.g. `glob`, `test-exclude`) alone.
2. **`ws 8.0.0 - 8.20.0`** — `GHSA-58qx-3vcg-4xpx` (moderate; uninitialized-memory disclosure). `ws` is a direct dependency at `^8.20.0`; `npm audit fix` walks it forward to `8.20.1` inside the same major. No `package.json` change needed beyond the lockfile bump.

After these changes, `npm audit` reports `0 vulnerabilities`. CI's `security` job should go green again.

## Diff

```
 package-lock.json | 32 ++++++++++++++++----------------
 package.json      |  5 ++++-
 2 files changed, 20 insertions(+), 17 deletions(-)
```

## Test plan

- [x] `npm install` clean
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] `npm audit --audit-level=high --production` — 0 vulnerabilities
- [x] `npm run build` succeeds
- [x] `npm test` — 199/199 passing
- [x] `npm run lint` — clean (warnings pre-existing)
- [x] `npm run format:check` — clean
- [ ] CI: `security`, `test (20.x)`, `test (22.x)`, `build`, `integration-test`, `smoke-test`, `validate-acp-providers` all pass

## Scope notes

This PR is intentionally minimal — just the override + the lockfile bump from `npm audit fix`. The earlier merged PR #173 deliberately excluded these changes per maintainer request to keep that PR's diff scoped to ACP work; this is the follow-up that picks them up cleanly on top of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)