### PR TITLE
Add typed agent-server compatibility helpers

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -8,10 +8,14 @@ import {
   Workspace,
 } from '../index';
 import {
+  AgentServerVersionError,
   ApiKeysClient,
   BashClient,
+  clearAgentServerInfoCache,
+  compareAgentServerVersions,
   ConversationClient,
   FileClient,
+  isAgentServerVersionError,
   ProfilesClient,
   SecurityClient,
   ServerClient,
@@ -19,6 +23,7 @@ import {
   SettingsClient,
   SharedClient,
   SkillsClient,
+  WorkspacesClient,
 } from '../clients';
 
 const originalFetch = global.fetch;
@@ -26,6 +31,7 @@ const originalFetch = global.fetch;
 describe('Auxiliary API clients', () => {
   afterEach(() => {
     global.fetch = originalFetch;
+    clearAgentServerInfoCache();
     jest.restoreAllMocks();
   });
 
@@ -218,6 +224,113 @@ describe('Auxiliary API clients', () => {
       'http://example.com/api/skills/installed/my%20skill',
       expect.objectContaining({ method: 'GET' })
     );
+  });
+
+  it('WorkspacesClient checks agent-server version before listing workspaces', async () => {
+    const responses = [
+      { version: '1.23.0', uptime: 1, idle_time: 0 },
+      {
+        workspaces: [
+          {
+            id: '/repo',
+            name: 'repo',
+            path: '/repo',
+            parentPath: '/home',
+          },
+        ],
+        workspaceParents: [{ id: '/home', name: 'home', path: '/home' }],
+      },
+      {
+        workspaces: [
+          {
+            id: '/repo',
+            name: 'repo',
+            path: '/repo',
+            parentPath: '/home',
+          },
+          {
+            id: '/repo2',
+            name: 'repo2',
+            path: '/repo2',
+            parentPath: '/home',
+          },
+        ],
+        workspaceParents: [{ id: '/home', name: 'home', path: '/home' }],
+      },
+    ];
+    global.fetch = jest.fn().mockImplementation(() => {
+      const body = responses.shift();
+      return Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }) as typeof fetch;
+
+    const client = new WorkspacesClient({ host: 'http://example.com' });
+    const listed = await client.listWorkspaces();
+    const updated = await client.addWorkspaces([
+      { id: '/repo2', name: 'repo2', path: '/repo2', parentPath: '/home' },
+    ]);
+
+    expect(listed.workspaces).toHaveLength(1);
+    expect(updated.workspaces).toHaveLength(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://example.com/server_info',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://example.com/api/workspaces',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      'http://example.com/api/workspaces',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          workspaces: [{ id: '/repo2', name: 'repo2', path: '/repo2', parentPath: '/home' }],
+        }),
+      })
+    );
+  });
+
+  it('WorkspacesClient throws AgentServerVersionError for old agent servers', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ version: '1.22.1', uptime: 1, idle_time: 0 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new WorkspacesClient({ host: 'http://example.com' });
+
+    await expect(client.listWorkspaces()).rejects.toMatchObject({
+      code: 'AGENT_SERVER_VERSION_TOO_OLD',
+      feature: 'workspaces',
+      requiredVersion: '1.23.0',
+      actualVersion: '1.22.1',
+    });
+
+    try {
+      await client.listWorkspaces();
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentServerVersionError);
+      expect(isAgentServerVersionError(error)).toBe(true);
+    }
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('compares agent-server semantic versions', () => {
+    expect(compareAgentServerVersions('1.23.0', '1.23.0')).toBe(0);
+    expect(compareAgentServerVersions('v1.24.0+build.1', '1.23.0')).toBe(1);
+    expect(compareAgentServerVersions('1.22.9', '1.23.0')).toBe(-1);
+    expect(compareAgentServerVersions('1.23.0-rc.1', '1.23.0')).toBe(-1);
+    expect(compareAgentServerVersions('not-a-version', '1.23.0')).toBeNull();
   });
 
   it('BashClient.startCommand normalizes string requests', async () => {

--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -4,6 +4,7 @@ import {
   HttpClient,
   HttpError,
   RemoteConversation,
+  RemoteEventsList,
   RemoteWorkspace,
   Workspace,
 } from '../index';
@@ -77,6 +78,49 @@ describe('Auxiliary API clients', () => {
 
     expect(ready.status).toBe('initializing');
     expect(ready.message).toBe('Booting');
+  });
+
+  it('RemoteEventsList can be constructed from client options', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [], next_page_id: null }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const events = new RemoteEventsList({ baseUrl: 'http://example.com', apiKey: 'secret' }, 'c1');
+    const page = await events.search({ limit: 25 });
+
+    expect(page.items).toEqual([]);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/c1/events/search?limit=25',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'X-Session-API-Key': 'secret',
+        }),
+      })
+    );
+  });
+
+  it('ConversationClient.switchLLM posts an explicit LLM config', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new ConversationClient({ host: 'http://example.com' });
+    await client.switchLLM('c1', { model: 'gpt-4o', api_key: 'encrypted' });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/c1/switch_llm',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ llm: { model: 'gpt-4o', api_key: 'encrypted' } }),
+      })
+    );
   });
 
   it('SkillsClient.syncSkills posts to the sync endpoint', async () => {

--- a/src/client/agent-server-compatibility.ts
+++ b/src/client/agent-server-compatibility.ts
@@ -1,0 +1,149 @@
+import { HttpClient } from './http-client';
+import type { ServerInfo } from '../types/base';
+
+export const AGENT_SERVER_VERSION_ERROR_CODE = 'AGENT_SERVER_VERSION_TOO_OLD';
+
+export interface AgentServerFeatureRequirement {
+  feature: string;
+  displayName: string;
+  minVersion: string;
+}
+
+export const AgentServerFeatureRequirements = {
+  workspaces: {
+    feature: 'workspaces',
+    displayName: 'Workspaces',
+    minVersion: '1.23.0',
+  },
+} as const satisfies Record<string, AgentServerFeatureRequirement>;
+
+export class AgentServerVersionError extends Error {
+  public readonly code = AGENT_SERVER_VERSION_ERROR_CODE;
+  public readonly feature: string;
+  public readonly displayName: string;
+  public readonly requiredVersion: string;
+  public readonly actualVersion: string;
+
+  constructor({
+    requirement,
+    actualVersion,
+  }: {
+    requirement: AgentServerFeatureRequirement;
+    actualVersion: string;
+  }) {
+    super(
+      `${requirement.displayName} requires agent-server ${requirement.minVersion} or newer; this backend is running ${actualVersion}. Please upgrade your agent-server backend.`
+    );
+    this.name = 'AgentServerVersionError';
+    this.feature = requirement.feature;
+    this.displayName = requirement.displayName;
+    this.requiredVersion = requirement.minVersion;
+    this.actualVersion = actualVersion;
+
+    Object.setPrototypeOf(this, AgentServerVersionError.prototype);
+  }
+}
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease?: string;
+}
+
+let serverInfoCache = new WeakMap<HttpClient, Promise<ServerInfo>>();
+
+export function isAgentServerVersionError(error: unknown): error is AgentServerVersionError {
+  return (
+    error instanceof AgentServerVersionError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: unknown }).code === AGENT_SERVER_VERSION_ERROR_CODE)
+  );
+}
+
+export function clearAgentServerInfoCache(client?: HttpClient): void {
+  if (client) {
+    serverInfoCache.delete(client);
+    return;
+  }
+  serverInfoCache = new WeakMap<HttpClient, Promise<ServerInfo>>();
+}
+
+export async function getCachedAgentServerInfo(client: HttpClient): Promise<ServerInfo> {
+  const cached = serverInfoCache.get(client);
+  if (cached) {
+    return cached;
+  }
+
+  const request = client.get<ServerInfo>('/server_info').then((response) => response.data);
+  serverInfoCache.set(client, request);
+  return request;
+}
+
+export async function assertAgentServerSupports(
+  client: HttpClient,
+  requirement: AgentServerFeatureRequirement
+): Promise<ServerInfo> {
+  const serverInfo = await getCachedAgentServerInfo(client);
+  const actualVersion =
+    typeof serverInfo.version === 'string' && serverInfo.version.trim()
+      ? serverInfo.version.trim()
+      : 'unknown';
+  const comparison = compareAgentServerVersions(actualVersion, requirement.minVersion);
+
+  if (comparison === null || comparison < 0) {
+    throw new AgentServerVersionError({ requirement, actualVersion });
+  }
+
+  return serverInfo;
+}
+
+export function compareAgentServerVersions(actual: string, required: string): number | null {
+  const parsedActual = parseAgentServerVersion(actual);
+  const parsedRequired = parseAgentServerVersion(required);
+
+  if (!parsedActual || !parsedRequired) {
+    return null;
+  }
+
+  for (const key of ['major', 'minor', 'patch'] as const) {
+    if (parsedActual[key] > parsedRequired[key]) {
+      return 1;
+    }
+    if (parsedActual[key] < parsedRequired[key]) {
+      return -1;
+    }
+  }
+
+  if (parsedActual.prerelease && !parsedRequired.prerelease) {
+    return -1;
+  }
+  if (!parsedActual.prerelease && parsedRequired.prerelease) {
+    return 1;
+  }
+  if (parsedActual.prerelease && parsedRequired.prerelease) {
+    return parsedActual.prerelease.localeCompare(parsedRequired.prerelease);
+  }
+
+  return 0;
+}
+
+function parseAgentServerVersion(version: string): ParsedVersion | null {
+  const trimmed = version.trim().replace(/^v/, '');
+  const [withoutBuild] = trimmed.split('+');
+  const [core, prerelease] = withoutBuild.split('-', 2);
+  const parts = core.split('.');
+
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const [major, minor, patch] = parts.map((part) => Number(part));
+  if (![major, minor, patch].every((part) => Number.isInteger(part) && part >= 0)) {
+    return null;
+  }
+
+  return { major, minor, patch, prerelease };
+}

--- a/src/client/conversation-client.ts
+++ b/src/client/conversation-client.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from './http-client';
-import { Success } from '../types/base';
+import { LLM, Success } from '../types/base';
 import type {
   AskAgentResponse,
   ConfirmationResponseRequest,
@@ -138,7 +138,7 @@ export class ConversationClient {
     });
   }
 
-  async switchLLM(conversationId: string, llm: unknown): Promise<void> {
+  async switchLLM(conversationId: string, llm: LLM): Promise<void> {
     await this.client.post<Success>(`/api/conversations/${conversationId}/switch_llm`, { llm });
   }
 

--- a/src/client/conversation-client.ts
+++ b/src/client/conversation-client.ts
@@ -138,6 +138,10 @@ export class ConversationClient {
     });
   }
 
+  async switchLLM(conversationId: string, llm: unknown): Promise<void> {
+    await this.client.post<Success>(`/api/conversations/${conversationId}/switch_llm`, { llm });
+  }
+
   async deleteConversation(conversationId: string): Promise<void> {
     await this.client.delete<Success>(`/api/conversations/${conversationId}`);
   }

--- a/src/client/workspaces-client.ts
+++ b/src/client/workspaces-client.ts
@@ -1,0 +1,95 @@
+import {
+  AgentServerFeatureRequirements,
+  assertAgentServerSupports,
+} from './agent-server-compatibility';
+import { HttpClient } from './http-client';
+
+export interface WorkspacesClientOptions {
+  host: string;
+  apiKey?: string;
+  timeout?: number;
+}
+
+export interface WorkspaceItem {
+  id: string;
+  name: string;
+  path: string;
+  parentPath?: string | null;
+}
+
+export interface WorkspaceParentItem {
+  id: string;
+  name: string;
+  path: string;
+}
+
+export interface WorkspacesListResponse {
+  workspaces: WorkspaceItem[];
+  workspaceParents: WorkspaceParentItem[];
+}
+
+export interface DeleteWorkspaceResponse {
+  deleted: boolean;
+}
+
+export class WorkspacesClient {
+  public readonly host: string;
+  public readonly apiKey?: string;
+  private readonly client: HttpClient;
+
+  constructor(options: WorkspacesClientOptions) {
+    this.host = options.host.replace(/\/$/, '');
+    this.apiKey = options.apiKey;
+    this.client = new HttpClient({
+      baseUrl: this.host,
+      apiKey: this.apiKey,
+      timeout: options.timeout || 60000,
+    });
+  }
+
+  async listWorkspaces(): Promise<WorkspacesListResponse> {
+    await this.ensureWorkspacesSupported();
+    const response = await this.client.get<WorkspacesListResponse>('/api/workspaces');
+    return response.data;
+  }
+
+  async addWorkspaces(workspaces: WorkspaceItem[]): Promise<WorkspacesListResponse> {
+    await this.ensureWorkspacesSupported();
+    const response = await this.client.post<WorkspacesListResponse>('/api/workspaces', {
+      workspaces,
+    });
+    return response.data;
+  }
+
+  async deleteWorkspace(path: string): Promise<DeleteWorkspaceResponse> {
+    await this.ensureWorkspacesSupported();
+    const response = await this.client.delete<DeleteWorkspaceResponse>('/api/workspaces', {
+      params: { path },
+    });
+    return response.data;
+  }
+
+  async addWorkspaceParents(parents: WorkspaceParentItem[]): Promise<WorkspacesListResponse> {
+    await this.ensureWorkspacesSupported();
+    const response = await this.client.post<WorkspacesListResponse>('/api/workspaces/parents', {
+      parents,
+    });
+    return response.data;
+  }
+
+  async deleteWorkspaceParent(path: string): Promise<DeleteWorkspaceResponse> {
+    await this.ensureWorkspacesSupported();
+    const response = await this.client.delete<DeleteWorkspaceResponse>('/api/workspaces/parents', {
+      params: { path },
+    });
+    return response.data;
+  }
+
+  close(): void {
+    this.client.close();
+  }
+
+  private async ensureWorkspacesSupported(): Promise<void> {
+    await assertAgentServerSupports(this.client, AgentServerFeatureRequirements.workspaces);
+  }
+}

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -13,6 +13,17 @@ export { SecurityClient } from './client/security-client';
 export { ApiKeysClient } from './client/api-keys-client';
 export { SessionClient } from './client/session-client';
 export { SharedClient } from './client/shared-client';
+export { WorkspacesClient } from './client/workspaces-client';
+export {
+  AGENT_SERVER_VERSION_ERROR_CODE,
+  AgentServerFeatureRequirements,
+  AgentServerVersionError,
+  assertAgentServerSupports,
+  clearAgentServerInfoCache,
+  compareAgentServerVersions,
+  getCachedAgentServerInfo,
+  isAgentServerVersionError,
+} from './client/agent-server-compatibility';
 
 export type { ServerClientOptions } from './client/server-client';
 export type { BashClientOptions } from './client/bash-client';
@@ -41,3 +52,11 @@ export type { SecurityClientOptions } from './client/security-client';
 export type { ApiKeysClientOptions } from './client/api-keys-client';
 export type { SessionClientOptions } from './client/session-client';
 export type { SharedClientOptions, SharedEventSearchOptions } from './client/shared-client';
+export type {
+  DeleteWorkspaceResponse,
+  WorkspacesClientOptions,
+  WorkspacesListResponse,
+  WorkspaceItem,
+  WorkspaceParentItem,
+} from './client/workspaces-client';
+export type { AgentServerFeatureRequirement } from './client/agent-server-compatibility';

--- a/src/events/remote-events-list.ts
+++ b/src/events/remote-events-list.ts
@@ -7,6 +7,7 @@
  */
 
 import { HttpClient, HttpError } from '../client/http-client';
+import type { HttpClientOptions } from '../client/http-client';
 import { Event, ConversationCallbackType } from '../types/base';
 import { EventPage } from '../types/base';
 
@@ -32,14 +33,17 @@ export interface EventSearchOptions {
   timestamp__lt?: string;
 }
 
+export type RemoteEventsListOptions = HttpClientOptions;
+
 export class RemoteEventsList {
   private client: HttpClient;
   private conversationId: string;
   private cachedEvents: Event[] = [];
   private cachedEventIds = new Set<string>();
 
-  constructor(client: HttpClient, conversationId: string) {
-    this.client = client;
+  constructor(clientOrOptions: HttpClient | RemoteEventsListOptions, conversationId: string) {
+    this.client =
+      clientOrOptions instanceof HttpClient ? clientOrOptions : new HttpClient(clientOrOptions);
     this.conversationId = conversationId;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,17 @@ export type { BashWebSocketClientOptions } from './events/bash-websocket-client'
 
 // HTTP client
 export { HttpClient, HttpError } from './client/http-client';
+export { WorkspacesClient } from './client/workspaces-client';
+export {
+  AGENT_SERVER_VERSION_ERROR_CODE,
+  AgentServerFeatureRequirements,
+  AgentServerVersionError,
+  assertAgentServerSupports,
+  clearAgentServerInfoCache,
+  compareAgentServerVersions,
+  getCachedAgentServerInfo,
+  isAgentServerVersionError,
+} from './client/agent-server-compatibility';
 
 // Types and interfaces
 export type {
@@ -233,6 +244,14 @@ export type {
 
 // Client options
 export type { HttpClientOptions, RequestOptions, HttpResponse } from './client/http-client';
+export type {
+  DeleteWorkspaceResponse,
+  WorkspacesClientOptions,
+  WorkspacesListResponse,
+  WorkspaceItem,
+  WorkspaceParentItem,
+} from './client/workspaces-client';
+export type { AgentServerFeatureRequirement } from './client/agent-server-compatibility';
 
 export type {
   AliveStatus,
@@ -350,6 +369,17 @@ import { RemoteEventsList } from './events/remote-events-list';
 import { WebSocketCallbackClient } from './events/websocket-client';
 import { BashWebSocketClient } from './events/bash-websocket-client';
 import { HttpClient, HttpError } from './client/http-client';
+import { WorkspacesClient } from './client/workspaces-client';
+import {
+  AGENT_SERVER_VERSION_ERROR_CODE,
+  AgentServerFeatureRequirements,
+  AgentServerVersionError,
+  assertAgentServerSupports,
+  clearAgentServerInfoCache,
+  compareAgentServerVersions,
+  getCachedAgentServerInfo,
+  isAgentServerVersionError,
+} from './client/agent-server-compatibility';
 import { EventSortOrder, AgentExecutionStatus, ConversationExecutionStatus } from './types/base';
 import { ConversationSortOrder } from './models/conversation';
 import { Agent } from './agent/agent';
@@ -391,6 +421,15 @@ export default {
   BashWebSocketClient,
   HttpClient,
   HttpError,
+  WorkspacesClient,
+  AGENT_SERVER_VERSION_ERROR_CODE,
+  AgentServerFeatureRequirements,
+  AgentServerVersionError,
+  assertAgentServerSupports,
+  clearAgentServerInfoCache,
+  compareAgentServerVersions,
+  getCachedAgentServerInfo,
+  isAgentServerVersionError,
   EventSortOrder,
   ConversationSortOrder,
   AgentExecutionStatus,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export { LocalWorkspace } from './workspace/local-workspace';
 export { Workspace, createWorkspace, createWorkspaceAuto } from './workspace/workspace';
 export { RemoteState } from './conversation/remote-state';
 export { RemoteEventsList } from './events/remote-events-list';
-export type { EventSearchOptions } from './events/remote-events-list';
+export type { EventSearchOptions, RemoteEventsListOptions } from './events/remote-events-list';
 
 // Stuck Detection
 export { StuckDetector, DEFAULT_STUCK_THRESHOLDS } from './conversation/stuck-detector';


### PR DESCRIPTION
## Summary
- add an agent-server compatibility helper with `AgentServerVersionError`
- define the workspace minimum server version as `1.23.0`
- add and export `WorkspacesClient` so workspace endpoints fail with a typed version error before hitting missing routes on old servers
- allow `RemoteEventsList` construction from client options and add `ConversationClient.switchLLM` so canvas callers do not need to instantiate `HttpClient` directly

## Verification
- `npm run build`
- `npm run format:check`
- `npm run lint` (existing warnings only)
- `npm test -- --runTestsByPath src/__tests__/api-clients.test.ts`
- `npm test`