### PR TITLE
test(profiles): add integration tests for ProfilesClient and switchLlm

### DIFF
--- a/src/__tests__/integration/deterministic-api.integration.test.ts
+++ b/src/__tests__/integration/deterministic-api.integration.test.ts
@@ -4,6 +4,7 @@ import {
   deleteWorkspaceFile,
   readWorkspaceFile,
   sleep,
+  uniqueDirName,
   uniqueFileName,
   workspaceFileExists,
 } from './test-utils';
@@ -132,6 +133,12 @@ describe('Deterministic API Integration Tests', () => {
           conversation.switchProfile('__profile_that_should_not_exist__')
         ).rejects.toBeInstanceOf(HttpError);
 
+        // switchLlm swaps the LLM object directly (no profile on disk), so it
+        // resolves where the missing-profile switchProfile above rejects.
+        await expect(
+          conversation.switchLlm({ model: 'dummy/model', api_key: 'dummy-key' })
+        ).resolves.toBeUndefined();
+
         const acpConversation = await manager.acp.createConversation(
           {
             kind: 'Agent',
@@ -211,6 +218,55 @@ describe('Deterministic API Integration Tests', () => {
       } finally {
         deleteWorkspaceFile(fileName);
         await workspace.executeCommand(`rm -rf ${repoDir}`);
+      }
+    },
+    config.testTimeout
+  );
+
+  it(
+    'round-trips a profile through save, get, list, activate, rename, and delete',
+    async () => {
+      const profileName = uniqueDirName('it-profile');
+      const renamedProfile = `${profileName}-renamed`;
+      const llm = { model: 'dummy/model', api_key: 'dummy-key' };
+
+      try {
+        const saved = await manager.profiles.saveProfile(profileName, { llm });
+        expect(saved.name).toBe(profileName);
+
+        const detail = await manager.profiles.getProfile(profileName);
+        expect(detail.name).toBe(profileName);
+        // The default (no X-Expose-Secrets) response nulls api_key and reports
+        // the presence of the saved key via api_key_set instead.
+        expect(detail.config.api_key).toBeNull();
+        expect(detail.api_key_set).toBe(true);
+
+        const list = await manager.profiles.listProfiles();
+        expect(list.profiles.some((profile) => profile.name === profileName)).toBe(true);
+
+        const activated = await manager.profiles.activateProfile(profileName);
+        expect(activated.name).toBe(profileName);
+        expect(activated.llm_applied).toBe(true);
+
+        const afterActivate = await manager.profiles.listProfiles();
+        expect(afterActivate.active_profile).toBe(profileName);
+
+        const renamed = await manager.profiles.renameProfile(profileName, renamedProfile);
+        expect(renamed.name).toBe(renamedProfile);
+
+        const renamedDetail = await manager.profiles.getProfile(renamedProfile);
+        expect(renamedDetail.name).toBe(renamedProfile);
+        // The original name stops resolving once the profile is renamed.
+        await expect(manager.profiles.getProfile(profileName)).rejects.toBeInstanceOf(HttpError);
+
+        const deleted = await manager.profiles.deleteProfile(renamedProfile);
+        expect(deleted.name).toBe(renamedProfile);
+
+        const finalList = await manager.profiles.listProfiles();
+        expect(finalList.profiles.some((profile) => profile.name === renamedProfile)).toBe(false);
+      } finally {
+        await manager.profiles.deleteProfile(profileName).catch(() => undefined);
+        await manager.profiles.deleteProfile(renamedProfile).catch(() => undefined);
       }
     },
     config.testTimeout

--- a/src/__tests__/integration/deterministic-api.integration.test.ts
+++ b/src/__tests__/integration/deterministic-api.integration.test.ts
@@ -133,11 +133,17 @@ describe('Deterministic API Integration Tests', () => {
           conversation.switchProfile('__profile_that_should_not_exist__')
         ).rejects.toBeInstanceOf(HttpError);
 
-        // switchLlm swaps the LLM object directly (no profile on disk), so it
-        // resolves where the missing-profile switchProfile above rejects.
-        await expect(
-          conversation.switchLlm({ model: 'dummy/model', api_key: 'dummy-key' })
-        ).resolves.toBeUndefined();
+        // switchLlm swaps the LLM in place, keyed by usage_id (first-write-wins
+        // in the registry). Reusing the agent's existing usage_id would be a
+        // silent no-op, so use a fresh one and read the model back off the
+        // agent to prove the swap actually took effect.
+        await conversation.switchLlm({
+          model: 'dummy/switched-model',
+          api_key: 'dummy-key',
+          usage_id: 'switched',
+        });
+        const switchedAgent = await conversation.state.getAgent();
+        expect(switchedAgent.llm.model).toBe('dummy/switched-model');
 
         const acpConversation = await manager.acp.createConversation(
           {
@@ -236,8 +242,10 @@ describe('Deterministic API Integration Tests', () => {
 
         const detail = await manager.profiles.getProfile(profileName);
         expect(detail.name).toBe(profileName);
-        // The default (no X-Expose-Secrets) response nulls api_key and reports
-        // the presence of the saved key via api_key_set instead.
+        // The saved LLM config round-trips...
+        expect(detail.config.model).toBe('dummy/model');
+        // ...but the default (no X-Expose-Secrets) response nulls api_key and
+        // reports the presence of the saved key via api_key_set instead.
         expect(detail.config.api_key).toBeNull();
         expect(detail.api_key_set).toBe(true);
 
@@ -256,6 +264,12 @@ describe('Deterministic API Integration Tests', () => {
 
         const renamedDetail = await manager.profiles.getProfile(renamedProfile);
         expect(renamedDetail.name).toBe(renamedProfile);
+        // The config survives the (atomic) rename...
+        expect(renamedDetail.config.model).toBe('dummy/model');
+        // ...and because the renamed profile was the active one, the
+        // active_profile pointer follows it to the new name.
+        const afterRename = await manager.profiles.listProfiles();
+        expect(afterRename.active_profile).toBe(renamedProfile);
         // The original name stops resolving once the profile is renamed.
         await expect(manager.profiles.getProfile(profileName)).rejects.toBeInstanceOf(HttpError);
 


### PR DESCRIPTION
## Summary

Follow-up to #148, which shipped `ProfilesClient` and `RemoteConversation.switchLlm` with mocked unit tests only (mocked `global.fetch` verifies wire shape but not server-side drift). This adds the live-server integration coverage tracked in #149, in `deterministic-api.integration.test.ts`.

**Profiles CRUD round-trip** — `save → get → list → activate → rename → delete` via `manager.profiles` against a running agent-server. Beyond exercising each endpoint, it asserts behavior a mock can't:
- the saved LLM **config round-trips** (`config.model`) and survives the atomic rename;
- the default (no `X-Expose-Secrets`) response **nulls `api_key`** and reports `api_key_set` instead;
- `active_profile` **tracks** the active profile across `activate` and **follows it through a rename** to the new name;
- the old name **404s** once renamed; the profile is gone from the list after delete.

Both names are cleaned up in `finally` (`deleteProfile` is idempotent server-side).

**`switchLlm`** — next to the existing `switchProfile` 404 check. `switchLlm` swaps the LLM in place keyed by `usage_id` (first-write-wins in the registry), so it switches to a **fresh `usage_id`** and reads the model back off the agent (`state.getAgent()`) to prove the swap actually took effect — reusing the agent's existing `usage_id` would be a silent no-op.

Both tests are deterministic (a dummy LLM, no provider calls) and live in `deterministic-api.integration.test.ts`, so they run in CI's **deterministic** integration job (`npm run test:integration:deterministic`) without an LLM key.

## Tasks from #149

- [x] Profiles CRUD round-trip integration test (`save → get → list → activate → rename → delete`).
- [x] `switchLlm` assertion next to the existing `switchProfile` 404 check.
- [ ] End-to-end coverage of `X-Expose-Secrets: encrypted | plaintext` (cipher round-trip).

The `X-Expose-Secrets` item stays deferred. The SDK feature it was blocked on (software-agent-sdk#3161) is now in the agent-server image CI runs (v1.23.0), but the `encrypted` round-trip needs an agent-server started with `OH_SECRET_KEY` configured — without a cipher the server returns 503 (`Encryption not available: OH_SECRET_KEY is not configured`). The current `integration-tests.yml` workflow starts the container without a cipher, so covering that mode is a separate change (workflow + a cipher-aware test). Leaving #149 open to track it.

## Verification

- `npm run lint`, `npm run format:check` — clean; `npm test` — unit suite green.
- New integration file type-checks under `--strict`.
- The endpoints and behaviors exercised (profiles router, `/switch_llm`, config round-trip, `active_profile` tracking through rename, `usage_id` swap semantics, 404-after-rename, idempotent delete) were verified against the agent-server source at the exact `v1.23.0` tag CI runs.
