### PR TITLE
feat(acp): mirror available_models / default_model from openhands-sdk

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -217,7 +217,7 @@ export type {
 
 // ACP provider registry (mirrors openhands-sdk; see scripts/validate-acp-providers.mjs)
 export { ACP_PROVIDERS, ACP_SETTINGS_KEYS, getAcpProvider } from './models/acp';
-export type { ACPProviderInfo, ACPProviderKey } from './models/acp';
+export type { ACPModelOption, ACPProviderInfo, ACPProviderKey } from './models/acp';
 
 // Conversation models
 export type {

--- a/src/models/acp-providers.json
+++ b/src/models/acp-providers.json
@@ -80,6 +80,6 @@
       { "id": "gemini-2.5-flash", "label": "Gemini 2.5 Flash" },
       { "id": "gemini-2.5-flash-lite", "label": "Gemini 2.5 Flash Lite" }
     ],
-    "default_model": "gemini-2.5-pro"
+    "default_model": "auto-gemini-2.5"
   }
 }

--- a/src/models/acp-providers.json
+++ b/src/models/acp-providers.json
@@ -8,7 +8,20 @@
     "default_session_mode": "bypassPermissions",
     "agent_name_patterns": ["claude-agent"],
     "supports_set_session_model": false,
-    "session_meta_key": "claudeCode"
+    "session_meta_key": "claudeCode",
+    "available_models": [
+      { "id": "claude-opus-4-7", "label": "Claude Opus 4.7" },
+      { "id": "claude-opus-4-6", "label": "Claude Opus 4.6" },
+      { "id": "opus[1m]", "label": "Claude Opus (1M)" },
+      { "id": "claude-opus-4-5", "label": "Claude Opus 4.5" },
+      { "id": "claude-opus-4-1-20250805", "label": "Claude Opus 4.1" },
+      { "id": "claude-sonnet-4-6", "label": "Claude Sonnet 4.6" },
+      { "id": "sonnet[1m]", "label": "Claude Sonnet (1M)" },
+      { "id": "claude-sonnet-4-5", "label": "Claude Sonnet 4.5" },
+      { "id": "claude-haiku-4-5", "label": "Claude Haiku 4.5" },
+      { "id": "opusplan", "label": "Opus (plan) + Sonnet (execute)" }
+    ],
+    "default_model": "claude-opus-4-7"
   },
   "codex": {
     "key": "codex",
@@ -19,7 +32,30 @@
     "default_session_mode": "full-access",
     "agent_name_patterns": ["codex-acp"],
     "supports_set_session_model": true,
-    "session_meta_key": null
+    "session_meta_key": null,
+    "available_models": [
+      { "id": "gpt-5.5/low", "label": "GPT-5.5 (low)" },
+      { "id": "gpt-5.5/medium", "label": "GPT-5.5 (medium)" },
+      { "id": "gpt-5.5/high", "label": "GPT-5.5 (high)" },
+      { "id": "gpt-5.5/xhigh", "label": "GPT-5.5 (xhigh)" },
+      { "id": "gpt-5.4/low", "label": "GPT-5.4 (low)" },
+      { "id": "gpt-5.4/medium", "label": "GPT-5.4 (medium)" },
+      { "id": "gpt-5.4/high", "label": "GPT-5.4 (high)" },
+      { "id": "gpt-5.4/xhigh", "label": "GPT-5.4 (xhigh)" },
+      { "id": "gpt-5.4-mini/low", "label": "GPT-5.4 Mini (low)" },
+      { "id": "gpt-5.4-mini/medium", "label": "GPT-5.4 Mini (medium)" },
+      { "id": "gpt-5.4-mini/high", "label": "GPT-5.4 Mini (high)" },
+      { "id": "gpt-5.4-mini/xhigh", "label": "GPT-5.4 Mini (xhigh)" },
+      { "id": "gpt-5.3-codex/low", "label": "GPT-5.3 Codex (low)" },
+      { "id": "gpt-5.3-codex/medium", "label": "GPT-5.3 Codex (medium)" },
+      { "id": "gpt-5.3-codex/high", "label": "GPT-5.3 Codex (high)" },
+      { "id": "gpt-5.3-codex/xhigh", "label": "GPT-5.3 Codex (xhigh)" },
+      { "id": "gpt-5.2/low", "label": "GPT-5.2 (low)" },
+      { "id": "gpt-5.2/medium", "label": "GPT-5.2 (medium)" },
+      { "id": "gpt-5.2/high", "label": "GPT-5.2 (high)" },
+      { "id": "gpt-5.2/xhigh", "label": "GPT-5.2 (xhigh)" }
+    ],
+    "default_model": "gpt-5.5/medium"
   },
   "gemini-cli": {
     "key": "gemini-cli",
@@ -30,6 +66,20 @@
     "default_session_mode": "yolo",
     "agent_name_patterns": ["gemini-cli"],
     "supports_set_session_model": true,
-    "session_meta_key": null
+    "session_meta_key": null,
+    "available_models": [
+      { "id": "auto-gemini-3", "label": "Auto (Gemini 3)" },
+      { "id": "auto-gemini-2.5", "label": "Auto (Gemini 2.5)" },
+      { "id": "gemini-3.1-pro-preview", "label": "Gemini 3.1 Pro (preview)" },
+      { "id": "gemini-3-flash-preview", "label": "Gemini 3 Flash (preview)" },
+      {
+        "id": "gemini-3.1-flash-lite-preview",
+        "label": "Gemini 3.1 Flash Lite (preview)"
+      },
+      { "id": "gemini-2.5-pro", "label": "Gemini 2.5 Pro" },
+      { "id": "gemini-2.5-flash", "label": "Gemini 2.5 Flash" },
+      { "id": "gemini-2.5-flash-lite", "label": "Gemini 2.5 Flash Lite" }
+    ],
+    "default_model": "gemini-2.5-pro"
   }
 }

--- a/src/models/acp.ts
+++ b/src/models/acp.ts
@@ -23,6 +23,17 @@ import providersData from './acp-providers.json';
 export type ACPProviderKey = 'claude-code' | 'codex' | 'gemini-cli';
 
 /**
+ * One selectable model for a built-in ACP provider's model picker. Mirrors
+ * `openhands.sdk.settings.acp_providers.ACPModelOption` field-for-field.
+ */
+export interface ACPModelOption {
+  /** Exact model identifier sent to the ACP server as `acp_model`. */
+  readonly id: string;
+  /** Human-readable label shown in the model picker (e.g. `"Claude Opus 4.7"`). */
+  readonly label: string;
+}
+
+/**
  * Immutable metadata record for one built-in ACP provider. Mirrors
  * `openhands.sdk.settings.acp_providers.ACPProviderInfo` field-for-field.
  */
@@ -42,6 +53,17 @@ export interface ACPProviderInfo {
   readonly supports_set_session_model: boolean;
   /** Top-level `_meta` key for model selection, or `null`. */
   readonly session_meta_key: string | null;
+  /**
+   * Curated `acp_model` candidates surfaced in this provider's model picker.
+   * Suggestions, not authoritative access checks — a custom `acp_model` is
+   * always allowed, and availability depends on the account's plan tier.
+   */
+  readonly available_models: readonly ACPModelOption[];
+  /**
+   * Model ID preselected when none is configured (one of {@link available_models}),
+   * or `null` to let the ACP server pick its own default.
+   */
+  readonly default_model: string | null;
 }
 
 export const ACP_PROVIDERS: Readonly<Record<ACPProviderKey, ACPProviderInfo>> =


### PR DESCRIPTION
## Summary

Mirrors the two new `ACPProviderInfo` fields added upstream in **OpenHands/software-agent-sdk#3389** (`available_models` + `default_model`) into this client's ACP registry, so TypeScript consumers — notably **agent-canvas** — can source ACP model-picker options from `@openhands/typescript-client` instead of hardcoding their own copies.

## Changes

- **`src/models/acp.ts`** — new `ACPModelOption` interface (`id`, `label`); `available_models: readonly ACPModelOption[]` and `default_model: string | null` added to `ACPProviderInfo`. `ACPModelOption` re-exported from `src/index.ts`.
- **`src/models/acp-providers.json`** — model lists + `default_model` for `claude-code` / `codex` / `gemini-cli`, generated directly from the Python `ACP_PROVIDERS` registry so `scripts/check-acp-drift.py` matches field-for-field.

## Validation

- `npm run build` (tsc) clean; `npm run format:check` clean; `npm run lint` 0 errors; `npx jest acp` → **209 passed**.
- `scripts/check-acp-drift.py` **passes against the #3389 SDK branch** (verified locally).

## ⚠️ Ordering — depends on SDK #3389

`scripts/requirements-acp-check.txt` pins `openhands-sdk @ main` **by design**. So the `validate-acp-providers` CI job here will be **red until OpenHands/software-agent-sdk#3389 merges to main** — at which point it turns green automatically (CI reinstalls the SDK from `main`).

**Merge order:** software-agent-sdk#3389 → this PR → bump agent-canvas's `@openhands/typescript-client` pin (then agent-canvas can drop its hardcoded ACP model lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
