### PR TITLE
Prepare TypeScript client v1.23.1 release

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,7 +16,7 @@ env:
   AGENT_SERVER_PORT: 8010
   HOST_WORKSPACE_DIR: /tmp/agent-workspace
   AGENT_WORKSPACE_DIR: /workspace
-  AGENT_SERVER_IMAGE: ghcr.io/openhands/agent-server:b1235d0-python # software-agent-sdk v1.23.0
+  AGENT_SERVER_IMAGE: ghcr.io/openhands/agent-server:71b070d-python # software-agent-sdk v1.23.1
 
 jobs:
   integration-test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,10 +304,10 @@ Integration tests are in `src/__tests__/integration/` and require a running agen
 export LLM_API_KEY="your-api-key"
 export LLM_MODEL="anthropic/claude-sonnet-4-5-20250929"
 
-# Start agent-server in Docker (software-agent-sdk v1.23.0)
+# Start agent-server in Docker (software-agent-sdk v1.23.1)
 docker run -d --name agent-server -p 8010:8000 \
   -v /tmp/agent-workspace:/workspace \
-  ghcr.io/openhands/agent-server:b1235d0-python
+  ghcr.io/openhands/agent-server:71b070d-python
 
 # Run integration tests
 npm run test:integration
@@ -336,7 +336,7 @@ Required GitHub secrets:
 
 ### CI Image Version
 
-- The integration workflow pins `ghcr.io/openhands/agent-server:b1235d0-python`, which corresponds to the `software-agent-sdk` release `v1.23.0`.
+- The integration workflow pins `ghcr.io/openhands/agent-server:71b070d-python`, which corresponds to the `software-agent-sdk` release `v1.23.1`.
 - Keep the TypeScript client tests strict against that released server image rather than adding compatibility fallbacks for older prerelease builds.
 
 ## Agent Behavior Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ export LLM_MODEL="anthropic/claude-sonnet-4-5-20250929"
 
 docker run -d --name agent-server -p 8010:8000 \
   -v /tmp/agent-workspace:/workspace \
-  ghcr.io/openhands/agent-server:7c37803-python
+  ghcr.io/openhands/agent-server:71b070d-python
 
 npm run test:integration
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ docker run -p 8000:8000 -p 8001:8001 \
   -e OH_ENABLE_VNC=false \
   -e SESSION_API_KEY="$SESSION_API_KEY" \
   -e OH_ALLOW_CORS_ORIGINS='["*"]' \
-  ghcr.io/all-hands-ai/agent-server:78938ee-python
+  ghcr.io/openhands/agent-server:71b070d-python
 ```
 
 ### Creating a Conversation
@@ -377,14 +377,14 @@ Integration tests require a running agent-server in Docker with a mounted worksp
    chmod 777 /tmp/agent-workspace
    ```
 
-2. Start the agent-server container (software-agent-sdk v1.18.1):
+2. Start the agent-server container (software-agent-sdk v1.23.1):
 
    ```bash
    docker run -d \
      --name agent-server \
      -p 8010:8000 \
      -v /tmp/agent-workspace:/workspace \
-     ghcr.io/openhands/agent-server:7c37803-python
+     ghcr.io/openhands/agent-server:71b070d-python
    ```
 
 3. Wait for the server to be ready:


### PR DESCRIPTION
## Summary
- Bump the pinned agent-server image used by integration tests from the software-agent-sdk v1.23.0 image to the v1.23.1 release image (`71b070d-python`).
- Refresh README, CONTRIBUTING, and AGENTS local integration-test instructions to use the same v1.23.1 agent-server image.
- This completes the release prep from #179 by ensuring the dependent agent-server version is actually bumped before tagging `v1.23.1`.

## Verification
- `npm ci` (including `prepare` / build)
- `npm test`
- `git diff --check`
- `docker buildx imagetools inspect ghcr.io/openhands/agent-server:71b070d-python`

## Release note
After this PR merges, create/push tag `v1.23.1` on `main` to trigger the TypeScript client Release workflow and publish `@openhands/typescript-client@1.23.1`.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/92364c78-edb6-433c-943f-3a6296b16caa)