### PR TITLE
feat: add npm (npmjs.org) publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -22,12 +23,27 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
+      # Trusted publishing requires Node 22.14.0+ and npm 11.5.1+
+      # See: https://docs.npmjs.com/trusted-publishers/
+      - name: Set up Node.js for npm trusted publishing
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           registry-url: https://registry.npmjs.org
+
+      - name: Verify npm version supports trusted publishing
+        run: |
+          echo "Node version: $(node --version)"
+          echo "npm version: $(npm --version)"
+          NPM_VERSION=$(npm --version)
+          NPM_MAJOR=$(echo $NPM_VERSION | cut -d. -f1)
+          NPM_MINOR=$(echo $NPM_VERSION | cut -d. -f2)
+          if [ "$NPM_MAJOR" -lt 11 ] || ([ "$NPM_MAJOR" -eq 11 ] && [ "$NPM_MINOR" -lt 5 ]); then
+            echo "Error: npm 11.5.1+ required for trusted publishing, got $NPM_VERSION"
+            exit 1
+          fi
+          echo "✓ npm $NPM_VERSION meets trusted publishing requirements"
 
       # The repo's .npmrc redirects @openhands to GitHub Packages;
       # remove it so this job publishes to the public npm registry.
@@ -62,7 +78,5 @@ jobs:
           fi
           echo "✓ Version $PACKAGE_VERSION matches release tag"
 
-      - name: Publish to npm
-        run: npm publish --access public --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm with provenance
+        run: npm publish --access public --provenance --tag latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish:
@@ -23,27 +22,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      # Trusted publishing requires Node 22.14.0+ and npm 11.5.1+
-      # See: https://docs.npmjs.com/trusted-publishers/
-      - name: Set up Node.js for npm trusted publishing
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '20'
           cache: npm
           registry-url: https://registry.npmjs.org
-
-      - name: Verify npm version supports trusted publishing
-        run: |
-          echo "Node version: $(node --version)"
-          echo "npm version: $(npm --version)"
-          NPM_VERSION=$(npm --version)
-          NPM_MAJOR=$(echo $NPM_VERSION | cut -d. -f1)
-          NPM_MINOR=$(echo $NPM_VERSION | cut -d. -f2)
-          if [ "$NPM_MAJOR" -lt 11 ] || ([ "$NPM_MAJOR" -eq 11 ] && [ "$NPM_MINOR" -lt 5 ]); then
-            echo "Error: npm 11.5.1+ required for trusted publishing, got $NPM_VERSION"
-            exit 1
-          fi
-          echo "✓ npm $NPM_VERSION meets trusted publishing requirements"
 
       # The repo's .npmrc redirects @openhands to GitHub Packages;
       # remove it so this job publishes to the public npm registry.
@@ -78,5 +62,7 @@ jobs:
           fi
           echo "✓ Version $PACKAGE_VERSION matches release tag"
 
-      - name: Publish to npm with provenance
-        run: npm publish --access public --provenance --tag latest
+      - name: Publish to npm
+        run: npm publish --access public --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,82 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: npm-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # Trusted publishing requires Node 22.14.0+ and npm 11.5.1+
+      # See: https://docs.npmjs.com/trusted-publishers/
+      - name: Set up Node.js for npm trusted publishing
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify npm version supports trusted publishing
+        run: |
+          echo "Node version: $(node --version)"
+          echo "npm version: $(npm --version)"
+          NPM_VERSION=$(npm --version)
+          NPM_MAJOR=$(echo $NPM_VERSION | cut -d. -f1)
+          NPM_MINOR=$(echo $NPM_VERSION | cut -d. -f2)
+          if [ "$NPM_MAJOR" -lt 11 ] || ([ "$NPM_MAJOR" -eq 11 ] && [ "$NPM_MINOR" -lt 5 ]); then
+            echo "Error: npm 11.5.1+ required for trusted publishing, got $NPM_VERSION"
+            exit 1
+          fi
+          echo "✓ npm $NPM_VERSION meets trusted publishing requirements"
+
+      # The repo's .npmrc redirects @openhands to GitHub Packages;
+      # remove it so this job publishes to the public npm registry.
+      - name: Remove project .npmrc
+        run: rm -f .npmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Extract and set version from tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Publishing version: $TAG_VERSION"
+          npm version "$TAG_VERSION" --no-git-tag-version
+
+      - name: Validate version was set
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Error: package.json version ($PACKAGE_VERSION) doesn't match tag ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "✓ Version $PACKAGE_VERSION matches release tag"
+
+      - name: Publish to npm with provenance
+        run: npm publish --access public --provenance --tag latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js for npm trusted publishing
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: npm
           registry-url: https://registry.npmjs.org
 
@@ -56,17 +56,19 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Build package
-        run: npm run build
-
-      - name: Verify package contents
-        run: npm pack --dry-run
-
+      # Set version from tag BEFORE build so any source that reads
+      # package.json at compile time picks up the correct version.
       - name: Extract and set version from tag
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
           echo "Publishing version: $TAG_VERSION"
           npm version "$TAG_VERSION" --no-git-tag-version
+
+      - name: Build package
+        run: npm run build
+
+      - name: Verify package contents
+        run: npm pack --dry-run
 
       - name: Validate version was set
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@openhands:registry=https://npm.pkg.github.com

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,34 +1,37 @@
 # Publishing Guide
 
-This document explains how to publish the OpenHands TypeScript Client to GitHub Packages.
+This document explains how to publish the OpenHands TypeScript Client.
 
 ## Overview
 
-The package is published exclusively to **GitHub Packages** for GitHub-native integration.
+The package is published to **two registries** on every version tag:
+
+| Registry | Workflow | Auth |
+|----------|----------|------|
+| **npm** (`registry.npmjs.org`) | `.github/workflows/npm-publish.yml` | OIDC trusted publishing |
+| **GitHub Packages** (`npm.pkg.github.com`) | `.github/workflows/release.yml` | `GITHUB_TOKEN` |
 
 ## Automated Publishing (Recommended)
 
 ### Prerequisites
 
-- **GitHub Token**: Automatically provided by GitHub Actions as `GITHUB_TOKEN`
+- **npm trusted publishing**: The `@openhands/typescript-client` package on npmjs.org must have the `OpenHands/typescript-client` repository configured as a trusted publisher (see [npm docs](https://docs.npmjs.com/trusted-publishers/)).
+- **GitHub Token**: Automatically provided by GitHub Actions as `GITHUB_TOKEN` for GitHub Packages.
 
 ### Publishing Process
 
 1. **Create and push a version tag**:
 
    ```bash
-   git tag v1.0.0
-   git push origin v1.0.0
+   git tag v1.23.3
+   git push origin v1.23.3
    ```
 
-2. **The `Release` GitHub Action will automatically**:
-   - Run tests
-   - Build the package
-   - Update package.json version
-   - Publish to GitHub Packages
-   - Create a GitHub release with installation instructions
+2. **Two GitHub Actions run automatically**:
+   - `npm-publish.yml`: Tests → builds → publishes to **npm** with provenance
+   - `release.yml`: Tests → builds → publishes to **GitHub Packages** → creates a GitHub Release
 
-Only `.github/workflows/release.yml` should run on version tags. The manual publish workflow is for explicit `workflow_dispatch` recovery only and must not also run on tag pushes, otherwise it can race the release workflow and fail with a duplicate-version conflict.
+Only these two workflows should run on version tags. The manual publish workflow (`.github/workflows/publish-github-packages.yml`) is for explicit `workflow_dispatch` recovery only and must not also run on tag pushes, otherwise it can race the release workflow and fail with a duplicate-version conflict.
 
 ## Manual Publishing
 
@@ -68,9 +71,13 @@ Only `.github/workflows/release.yml` should run on version tags. The manual publ
 
 ## Installation Instructions for Users
 
-### From GitHub Packages
+### From npm (Recommended)
 
-#### Option 1: Configure .npmrc (Recommended)
+```bash
+npm install @openhands/typescript-client
+```
+
+### From GitHub Packages
 
 Add to your `.npmrc` file:
 
@@ -82,12 +89,6 @@ Then install:
 
 ```bash
 npm install @openhands/typescript-client
-```
-
-#### Option 2: Direct install with registry flag
-
-```bash
-npm install @openhands/typescript-client --registry=https://npm.pkg.github.com
 ```
 
 ## Troubleshooting
@@ -113,5 +114,6 @@ Common issues:
 
 ## Workflow Files
 
-- `.github/workflows/release.yml`: Main tag-triggered release workflow (GitHub Packages and GitHub Release)
+- `.github/workflows/npm-publish.yml`: Tag-triggered npm (npmjs.org) publish workflow (OIDC trusted publishing)
+- `.github/workflows/release.yml`: Tag-triggered GitHub Packages publish + GitHub Release workflow
 - `.github/workflows/publish-github-packages.yml`: Manual GitHub Packages recovery workflow (`workflow_dispatch` only)

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -8,14 +8,14 @@ The package is published to **two registries** on every version tag:
 
 | Registry | Workflow | Auth |
 |----------|----------|------|
-| **npm** (`registry.npmjs.org`) | `.github/workflows/npm-publish.yml` | OIDC trusted publishing |
+| **npm** (`registry.npmjs.org`) | `.github/workflows/npm-publish.yml` | `NPM_TOKEN` repo secret |
 | **GitHub Packages** (`npm.pkg.github.com`) | `.github/workflows/release.yml` | `GITHUB_TOKEN` |
 
 ## Automated Publishing (Recommended)
 
 ### Prerequisites
 
-- **npm trusted publishing**: The `@openhands/typescript-client` package on npmjs.org must have the `OpenHands/typescript-client` repository configured as a trusted publisher (see [npm docs](https://docs.npmjs.com/trusted-publishers/)).
+- **`NPM_TOKEN` repo secret**: An npm access token with publish permission for the `@openhands` scope, stored as a repository secret named `NPM_TOKEN`.
 - **GitHub Token**: Automatically provided by GitHub Actions as `GITHUB_TOKEN` for GitHub Packages.
 
 ### Publishing Process

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -8,14 +8,14 @@ The package is published to **two registries** on every version tag:
 
 | Registry | Workflow | Auth |
 |----------|----------|------|
-| **npm** (`registry.npmjs.org`) | `.github/workflows/npm-publish.yml` | `NPM_TOKEN` repo secret |
+| **npm** (`registry.npmjs.org`) | `.github/workflows/npm-publish.yml` | OIDC trusted publishing |
 | **GitHub Packages** (`npm.pkg.github.com`) | `.github/workflows/release.yml` | `GITHUB_TOKEN` |
 
 ## Automated Publishing (Recommended)
 
 ### Prerequisites
 
-- **`NPM_TOKEN` repo secret**: An npm access token with publish permission for the `@openhands` scope, stored as a repository secret named `NPM_TOKEN`.
+- **npm trusted publishing**: The `@openhands/typescript-client` package on npmjs.org must have the `OpenHands/typescript-client` repository configured as a trusted publisher (see [npm docs](https://docs.npmjs.com/trusted-publishers/)).
 - **GitHub Token**: Automatically provided by GitHub Actions as `GITHUB_TOKEN` for GitHub Packages.
 
 ### Publishing Process

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openhands/typescript-client",
-  "version": "0.1.1",
+  "version": "1.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openhands/typescript-client",
-      "version": "0.1.1",
+      "version": "1.23.3",
       "license": "MIT",
       "dependencies": {
         "@openrouter/sdk": "^0.12.35",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openhands/typescript-client",
-  "version": "0.1.1",
+  "version": "1.23.3",
   "description": "TypeScript client for OpenHands Agent Server",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Problem

`npm install -g @openhands/agent-canvas` fails because `@openhands/typescript-client` is specified as a git dependency. npm clones the repo and tries to run the `prepare` script (`npm run clean && npm run build`), but `rimraf` (a devDependency) isn't available during global installs:

```
npm error sh: rimraf: command not found
```

The package is currently only published to **GitHub Packages**, not the public npm registry.

## Solution

Add a new workflow (`.github/workflows/npm-publish.yml`) that publishes to **npmjs.org** using OIDC trusted publishing on every `v*` tag — the same approach used by `@openhands/agent-canvas`.

The existing GitHub Packages workflow (`release.yml`) is unchanged; both run in parallel on tag pushes.

## Before tagging a release

**One-time setup required on npmjs.org:**

1. Go to https://www.npmjs.com/ and sign in to the `@openhands` org
2. Create the package `@openhands/typescript-client` (or it will be created on first publish)
3. Navigate to the package settings → **Trusted Publishers**
4. Add a trusted publisher:
   - **Repository owner**: `OpenHands`
   - **Repository name**: `typescript-client`
   - **Workflow filename**: `npm-publish.yml`
   - **Environment**: *(leave blank)*

Once that's done, tag a release and both workflows will fire:

```bash
git tag v1.23.3
git push origin v1.23.3
```

## Follow-up

After the first successful npm publish, update `@openhands/agent-canvas` to depend on the npm package instead of the git URL:

```diff
- "@openhands/typescript-client": "git+https://github.com/OpenHands/typescript-client.git#v1.23.0"
+ "@openhands/typescript-client": "1.23.3"
```

This will fix `npm install -g @openhands/agent-canvas`.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e6077edc-4933-4836-af79-2628406d59fa)