### PR TITLE
feat(types): add load_project_skills flag to AgentContext

### DIFF
--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -41,6 +41,7 @@ export interface AgentContext {
   skills?: unknown[];
   system_message_suffix?: string | null;
   user_message_suffix?: string | null;
+  load_project_skills?: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
Surfaces the `load_project_skills` opt-in flag added to `AgentContext` in [software-agent-sdk #3346](https://github.com/OpenHands/software-agent-sdk/pull/3346) (shipped in v1.24.0). When `true`, the agent-server auto-loads project skills from the conversation workspace on the first `send_message()` / `run()`.

## Why this is the only change needed
`AgentContext` in `src/types/base.ts` already has an `[key: string]: unknown` escape hatch, so callers could pass the field today — but it wouldn't show up in autocomplete or type checks. This PR types the field explicitly. No endpoint or runtime change is required; the field flows through as-is on conversation start.

## Stacked on #193
This branch is cut from `chore/bump-agent-server-v1.24.0`. Base will auto-retarget to `main` once #193 merges.

## Out of scope
The sibling flags `load_user_skills` and `load_public_skills` are also untyped on the TS-side. Adding them is consistency cleanup, not part of v1.24.0 — happy to do in a follow-up if you want.

## Test plan
- [ ] `npm run build` (already green locally)
- [ ] Optional: write a TS snippet that passes `agent_context: { load_project_skills: true }` and confirm it type-checks.