### PR TITLE
feat(profiles): expose AgentProfile kind + ACP fields

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -4,6 +4,7 @@ import {
   ConversationManager,
   HttpClient,
   HttpError,
+  ProfileInfo,
   RemoteConversation,
   RemoteEventsList,
   RemoteWorkspace,
@@ -521,6 +522,70 @@ describe('Auxiliary API clients', () => {
         }),
       })
     );
+  });
+
+  it('ProfilesClient.saveProfile POSTs an ACP profile via agent_settings', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ name: 'local-codex', message: "Profile 'local-codex' saved" }),
+        { status: 201, headers: { 'content-type': 'application/json' } }
+      )
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const result = await client.saveProfile('local-codex', {
+      agent_settings: {
+        agent_kind: 'acp',
+        acp_server: 'codex',
+        acp_model: 'gpt-5-codex',
+        acp_command: ['npx', '-y', '@zed-industries/codex-acp'],
+        acp_args: [],
+        acp_env: {},
+      },
+    });
+
+    expect(result.name).toBe('local-codex');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/profiles/local-codex',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          agent_settings: {
+            agent_kind: 'acp',
+            acp_server: 'codex',
+            acp_model: 'gpt-5-codex',
+            acp_command: ['npx', '-y', '@zed-industries/codex-acp'],
+            acp_args: [],
+            acp_env: {},
+          },
+        }),
+      })
+    );
+  });
+
+  it('ProfilesClient.listProfiles surfaces the AgentProfile kind / acp fields', async () => {
+    const acpProfile: ProfileInfo = {
+      name: 'local-codex',
+      kind: 'acp',
+      model: 'gpt-5-codex',
+      base_url: null,
+      acp_server: 'codex',
+      acp_model: 'gpt-5-codex',
+      api_key_set: true,
+    };
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ profiles: [acpProfile], active_profile: 'local-codex' }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    ) as typeof fetch;
+
+    const client = new ProfilesClient({ host: 'http://example.com' });
+    const result = await client.listProfiles();
+
+    expect(result.profiles[0].kind).toBe('acp');
+    expect(result.profiles[0].acp_server).toBe('codex');
+    expect(result.profiles[0].acp_model).toBe('gpt-5-codex');
   });
 
   it('ProfilesClient.deleteProfile DELETEs the profile endpoint', async () => {

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -158,18 +158,22 @@ export type ProfileKind = 'openhands' | 'acp';
 
 export interface ProfileInfo {
   name: string;
-  /** AgentProfile kind; legacy LLM profiles report `openhands`. */
-  kind: ProfileKind;
+  /**
+   * AgentProfile kind; legacy LLM profiles report `openhands`. Optional so the
+   * client stays compatible with agent-servers that predate AgentProfiles and
+   * don't emit this field — treat a missing `kind` as `'openhands'`.
+   */
+  kind?: ProfileKind;
   /**
    * Display model. For `openhands` profiles this is the LLM model; for `acp`
    * profiles it mirrors `acp_model` so chip/label consumers still render.
    */
   model: string | null;
   base_url: string | null;
-  /** ACP backend key for `acp` profiles (else `null`). */
-  acp_server: string | null;
-  /** Configured ACP model for `acp` profiles (else `null`). */
-  acp_model: string | null;
+  /** ACP backend key for `acp` profiles (`null`/absent for `openhands`). */
+  acp_server?: string | null;
+  /** Configured ACP model for `acp` profiles (`null`/absent for `openhands`). */
+  acp_model?: string | null;
   api_key_set: boolean;
 }
 

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -149,10 +149,27 @@ export interface VSCodeStatusResponse {
   message?: string;
 }
 
+/**
+ * AgentProfile kind. `openhands` profiles carry an LLM config; `acp` profiles
+ * launch an ACP subprocess (see `acp_server` / `acp_model`). Legacy LLM-only
+ * profiles default to `openhands`. Mirrors the agent-server's profile model.
+ */
+export type ProfileKind = 'openhands' | 'acp';
+
 export interface ProfileInfo {
   name: string;
+  /** AgentProfile kind; legacy LLM profiles report `openhands`. */
+  kind: ProfileKind;
+  /**
+   * Display model. For `openhands` profiles this is the LLM model; for `acp`
+   * profiles it mirrors `acp_model` so chip/label consumers still render.
+   */
   model: string | null;
   base_url: string | null;
+  /** ACP backend key for `acp` profiles (else `null`). */
+  acp_server: string | null;
+  /** Configured ACP model for `acp` profiles (else `null`). */
+  acp_model: string | null;
   api_key_set: boolean;
 }
 
@@ -179,7 +196,20 @@ export interface ActivateProfileResponse {
 }
 
 export interface SaveProfileRequest {
-  llm: LLM;
+  /**
+   * Legacy LLM-only payload, saved as an `openhands` profile. Provide exactly
+   * one of `llm` or `agent_settings`.
+   */
+  llm?: LLM;
+  /**
+   * Full AgentSettings payload (discriminated by `agent_kind`). Use this to
+   * save ACP profiles, e.g.
+   * `{ agent_kind: 'acp', acp_server, acp_model, acp_command, acp_args, acp_env }`.
+   * Mutually exclusive with `llm`. Typed as a record because the agent-server
+   * validates it against the discriminated `AgentSettings` union.
+   */
+  agent_settings?: Record<string, unknown>;
+  /** Whether to persist secrets (API key / acp_env) with the profile. */
   include_secrets?: boolean;
 }
 


### PR DESCRIPTION
## What

Mirrors the agent-server's **AgentProfile** model (software-agent-sdk#3433) in the TypeScript client so consumers (agent-canvas) can read *and* create ACP profiles, not just LLM ones. This is the client piece that unblocks the frontend half of [agent-canvas#669](https://github.com/OpenHands/agent-canvas/issues/669) — today agent-canvas can only see LLM profiles because these types are LLM-only.

## Changes (`src/models/api.ts`)

- **`ProfileInfo`** gains:
  - `kind: 'openhands' | 'acp'` (new `ProfileKind` type) — legacy LLM profiles report `openhands`.
  - `acp_server: string | null`, `acp_model: string | null` for ACP profiles.
  - `model` mirrors `acp_model` for ACP profiles so chip/label consumers keep rendering.
- **`SaveProfileRequest`**: `llm` is now optional, and a new `agent_settings?: Record<string, unknown>` accepts the discriminated `AgentSettings` payload. ACP profiles are saved via:
  ```ts
  client.saveProfile(name, { agent_settings: { agent_kind: 'acp', acp_server, acp_model, acp_command, acp_args, acp_env } })
  ```
  Exactly one of `llm` / `agent_settings` is provided, matching the server contract. `agent_settings` is typed as a record (not a full union) consistent with how `SettingsApiResponse.agent_settings` is modeled here.

No client-method changes — `ProfilesClient.saveProfile` already forwards the request body, and `getProfile`/`activateProfile` are unchanged.

## Tests

`src/__tests__/api-clients.test.ts` adds coverage for the ACP `agent_settings` save path and the ACP `ProfileInfo` shape. Full suite: **215/215 passing**; `tsc` build clean; lint 0 errors.

## Related
- Backend: software-agent-sdk#3433 (persists ACP profiles)
- Frontend: agent-canvas#928 (runtime-compat picker; will consume these fields once this client version is published & bumped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)