### PR TITLE
feat(acp): AcpClient.getAuthStatus for /api/acp/auth-status

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -10,6 +10,7 @@ import {
   Workspace,
 } from '../index';
 import {
+  AcpClient,
   AgentServerVersionError,
   ApiKeysClient,
   BashClient,
@@ -1347,5 +1348,68 @@ describe('Auxiliary API clients', () => {
       'http://example.com/api/shared-events/search?conversation_id=shared-1&limit=50',
       expect.objectContaining({ method: 'GET' })
     );
+  });
+
+  it('AcpClient.getAuthStatus probes a provider via a query param', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          server: 'claude-code',
+          status: 'authenticated',
+          auth_methods: [],
+          agent_name: 'claude-code-acp',
+          agent_version: '1.2.3',
+          detail: null,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    ) as typeof fetch;
+
+    const client = new AcpClient({ host: 'http://example.com', apiKey: 'secret' });
+    const result = await client.getAuthStatus('claude-code');
+
+    expect(result.status).toBe('authenticated');
+    expect(result.agent_name).toBe('claude-code-acp');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/acp/auth-status?server=claude-code',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ 'X-Session-API-Key': 'secret' }),
+      })
+    );
+  });
+
+  it('AcpClient.getAuthStatus returns an unknown status without throwing', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          server: 'codex',
+          status: 'unknown',
+          auth_methods: [],
+          agent_name: '',
+          agent_version: '',
+          detail: 'FileNotFoundError: npx',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    ) as typeof fetch;
+
+    const client = new AcpClient({ host: 'http://example.com' });
+    const result = await client.getAuthStatus('codex');
+
+    expect(result.status).toBe('unknown');
+    expect(result.detail).toBe('FileNotFoundError: npx');
+  });
+
+  it('AcpClient.getAuthStatus surfaces a 422 for an unknown provider', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Unknown ACP server 'nope'." }), {
+        status: 422,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new AcpClient({ host: 'http://example.com' });
+    await expect(client.getAuthStatus('nope')).rejects.toMatchObject({ status: 422 });
   });
 });

--- a/src/client/acp-client.ts
+++ b/src/client/acp-client.ts
@@ -1,0 +1,54 @@
+import { HttpClient } from './http-client';
+import type { ACPAuthStatusResponse } from '../models/api';
+
+export interface AcpClientOptions {
+  host: string;
+  apiKey?: string;
+  timeout?: number;
+}
+
+/**
+ * Client for the agent server's ACP (Agent Client Protocol) routes under
+ * `/api/acp`.
+ */
+export class AcpClient {
+  public readonly host: string;
+  public readonly apiKey?: string;
+  private readonly client: HttpClient;
+
+  constructor(options: AcpClientOptions) {
+    this.host = options.host.replace(/\/$/, '');
+    this.apiKey = options.apiKey;
+    this.client = new HttpClient({
+      baseUrl: this.host,
+      apiKey: this.apiKey,
+      timeout: options.timeout || 60000,
+    });
+  }
+
+  /**
+   * Probe whether a provider's ACP CLI is already authenticated on the agent
+   * server — by a subscription login (Claude Pro/Max, ChatGPT, Google) or a
+   * pre-set API key.
+   *
+   * Drives the ACP `initialize` + `session/new` handshake server-side and sends
+   * no prompt, so it spends no model tokens. The endpoint always responds 200:
+   * a probe that cannot run is reported as `status: "unknown"` rather than an
+   * HTTP error, so callers fall back to the API-key fields instead of falsely
+   * claiming "not logged in". A genuinely unknown `server` is the one error
+   * case (HTTP 422).
+   *
+   * @param server Registry key of the provider to probe (e.g. `"claude-code"`,
+   *   `"codex"`, `"gemini-cli"`).
+   */
+  async getAuthStatus(server: string): Promise<ACPAuthStatusResponse> {
+    const response = await this.client.get<ACPAuthStatusResponse>('/api/acp/auth-status', {
+      params: { server },
+    });
+    return response.data;
+  }
+
+  close(): void {
+    this.client.close();
+  }
+}

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,4 +1,5 @@
 export { ServerClient } from './client/server-client';
+export { AcpClient } from './client/acp-client';
 export { BashClient } from './client/bash-client';
 export { CloudProxyClient } from './client/cloud-proxy-client';
 export { ConversationClient } from './client/conversation-client';
@@ -29,6 +30,7 @@ export {
 } from './client/agent-server-compatibility';
 
 export type { ServerClientOptions } from './client/server-client';
+export type { AcpClientOptions } from './client/acp-client';
 export type { BashClientOptions } from './client/bash-client';
 export type { CloudProxyClientOptions } from './client/cloud-proxy-client';
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,6 +291,8 @@ export type {
   DesktopUrlResponse,
   VSCodeUrlResponse,
   VSCodeStatusResponse,
+  ACPAuthStatusValue,
+  ACPAuthStatusResponse,
   ProfileInfo,
   ProfileListResponse,
   ProfileDetailResponse,

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -149,6 +149,39 @@ export interface VSCodeStatusResponse {
   message?: string;
 }
 
+/**
+ * Outcome of an ACP auth-status probe (`GET /api/acp/auth-status`).
+ *
+ * - `authenticated`   — `session/new` succeeded ⇒ the provider CLI is logged in
+ *   (by a subscription *or* a pre-set API key).
+ * - `unauthenticated` — the server is reachable but reports `auth_required`.
+ * - `unknown`         — the probe could not run/complete (subprocess won't
+ *   start, timeout, or a non-auth error); the caller should fall back to the
+ *   API-key fields rather than treat this as "not logged in".
+ */
+export type ACPAuthStatusValue = 'authenticated' | 'unauthenticated' | 'unknown';
+
+/**
+ * Response from `GET /api/acp/auth-status?server=<key>`. Mirrors the
+ * `ACPAuthStatusResponse` model in the agent server's `acp_auth_router`.
+ */
+export interface ACPAuthStatusResponse {
+  /** The ACP provider key that was probed (e.g. `"claude-code"`). */
+  server: string;
+  status: ACPAuthStatusValue;
+  /**
+   * Auth method ids advertised at `initialize`. Informational only — the menu
+   * of how to log in, not a logged-in signal.
+   */
+  auth_methods: string[];
+  /** ACP server name reported by the handshake (empty if unavailable). */
+  agent_name: string;
+  /** ACP server version reported by the handshake (empty if unavailable). */
+  agent_version: string;
+  /** Populated only when `status` is `"unknown"`: why the probe failed. */
+  detail: string | null;
+}
+
 export interface ProfileInfo {
   name: string;
   model: string | null;


### PR DESCRIPTION
## Summary

TypeScript-client side of the ACP subscription/login detection feature (OpenHands/agent-canvas#964). Adds a thin client for the new agent-server endpoint introduced in software-agent-sdk#3452, so the agent-canvas onboarding can show "✓ you're already logged in" instead of unconditionally asking for an API key.

## Changes

- **`AcpClient`** (`src/client/acp-client.ts`) with `getAuthStatus(server)` → `GET /api/acp/auth-status?server=<key>`, returning the typed `ACPAuthStatusResponse`.
- **Types** `ACPAuthStatusValue` (`'authenticated' | 'unauthenticated' | 'unknown'`) and `ACPAuthStatusResponse` (`{ server, status, auth_methods, agent_name, agent_version, detail }`) in `src/models/api.ts`, mirroring the server model.
- Exported from `clients.ts` (`AcpClient` + `AcpClientOptions`) and `index.ts` (the two types).
- Unit tests in `api-clients.test.ts`: authenticated probe (asserts URL/query param + session-key header), `unknown` returned without throwing, and a `422` for an unknown provider.

The endpoint always responds `200` with a `status` of `authenticated` / `unauthenticated` / `unknown` (a probe that can't run is `unknown`, not an HTTP error), so a caller can map `status` 1:1 onto the canvas `useAcpAuthStatus` hook.

## Consumed by

agent-canvas PR (wires `useAcpAuthStatus` to this endpoint). The agent-server endpoint lands in software-agent-sdk#3452.

Refs OpenHands/agent-canvas#964

🤖 Generated with [Claude Code](https://claude.com/claude-code)