### PR TITLE
docs(acp): clarify mcp_config is a shared field, not ACP-only

### DIFF
--- a/src/models/acp.ts
+++ b/src/models/acp.ts
@@ -90,9 +90,16 @@ export function getAcpProvider(key: string | null | undefined): ACPProviderInfo 
 }
 
 /**
- * Allow-list of fields that travel on an `ACPAgent` settings payload.
- * Mirrors `openhands.sdk.settings.model.ACPAgentSettings`'s field set.
- * Clients filter ACP-only fields out when switching to a non-ACP variant.
+ * Allow-list of the `acp_*`-prefixed fields that travel on an `ACPAgent`
+ * settings payload. Mirrors `openhands.sdk.settings.model.ACPAgentSettings`'s
+ * ACP-exclusive field set. Clients filter these out when switching to a
+ * non-ACP variant.
+ *
+ * Deliberately excludes `mcp_config`: it is also a valid `ACPAgent` field (its
+ * MCP servers are forwarded to the ACP subprocess at session creation), but it
+ * is **shared** with the OpenHands agent variant — so it must NOT be stripped
+ * when switching agent kinds. Treat `mcp_config` like `llm`/`agent_context`
+ * (shared, handled explicitly per variant), not as an ACP-only field.
  */
 export const ACP_SETTINGS_KEYS: readonly string[] = [
   'acp_command',


### PR DESCRIPTION
## What

`ACPAgentSettings` now accepts `mcp_config` (the SDK forwards its MCP servers to the ACP subprocess at session creation — see OpenHands/software-agent-sdk#3458).

This clarifies on `ACP_SETTINGS_KEYS` that `mcp_config` is **deliberately excluded** from this ACP-exclusive allow-list.

## Why

`ACP_SETTINGS_KEYS` is used to (a) copy ACP-only fields into an ACP payload and (b) **strip** them when switching to a non-ACP variant. `mcp_config` is **shared** with the OpenHands variant — adding it here would cause clients to delete `mcp_config` when switching agent kinds (and, in the agent-canvas adapter, would strip it right after the OpenHands builder preserved it). It must be handled per-variant like `llm` / `agent_context`, not stripped.

Comment-only change. `tsc` build + prettier + eslint clean.

Part of OpenHands/agent-canvas#993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)