### PR TITLE
feat(acp): add liftAgentContextSecrets to promote agent creds into request.secrets

### DIFF
--- a/src/__tests__/lift-acp-secrets.test.ts
+++ b/src/__tests__/lift-acp-secrets.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for liftAgentContextSecrets — the TypeScript equivalent of Python SDK's
+ * _start_request_kwargs(): promotes agent_context.secrets into the top-level
+ * request.secrets field so the agent-server seeds secret_registry from them.
+ */
+
+import { liftAgentContextSecrets } from '../models/conversation';
+import type { AgentBase, AgentContext } from '../types/base';
+import type { SecretObject, StaticSecret } from '../models/conversation';
+
+function staticSecret(value: string): StaticSecret {
+  return { kind: 'StaticSecret', value };
+}
+
+function makeAgent(contextSecrets?: Record<string, SecretObject>): AgentBase {
+  const agentContext: AgentContext & { secrets?: Record<string, SecretObject> } = contextSecrets
+    ? { secrets: contextSecrets }
+    : {};
+  return {
+    kind: 'acp',
+    llm: { model: 'claude-sonnet-4-5' },
+    agent_context: agentContext,
+  };
+}
+
+describe('liftAgentContextSecrets', () => {
+  it('returns empty object when agent has no context secrets and no panel secrets', () => {
+    const agent = makeAgent();
+    expect(liftAgentContextSecrets(agent)).toEqual({});
+  });
+
+  it('returns empty object when agent_context is null', () => {
+    const agent: AgentBase = { kind: 'acp', llm: { model: 'claude-sonnet-4-5' }, agent_context: null };
+    expect(liftAgentContextSecrets(agent)).toEqual({});
+  });
+
+  it('lifts agent_context.secrets into result', () => {
+    const cred = staticSecret('sk-provider-key');
+    const agent = makeAgent({ ANTHROPIC_API_KEY: cred });
+
+    const result = liftAgentContextSecrets(agent);
+
+    expect(result).toEqual({ ANTHROPIC_API_KEY: cred });
+  });
+
+  it('panel secrets win when they conflict with agent_context secrets (mirror SDK merge order)', () => {
+    const providerCred = staticSecret('sk-provider-key');
+    const panelCred = staticSecret('sk-panel-key');
+    const agent = makeAgent({ ANTHROPIC_API_KEY: providerCred });
+
+    const result = liftAgentContextSecrets(agent, { ANTHROPIC_API_KEY: panelCred });
+
+    expect(result['ANTHROPIC_API_KEY']).toBe(panelCred);
+  });
+
+  it('non-conflicting panel secrets are merged alongside agent_context secrets', () => {
+    const providerCred = staticSecret('sk-provider-key');
+    const githubToken = staticSecret('ghp-panel');
+    const agent = makeAgent({ ANTHROPIC_API_KEY: providerCred });
+
+    const result = liftAgentContextSecrets(agent, { GITHUB_TOKEN: githubToken });
+
+    expect(result['ANTHROPIC_API_KEY']).toBe(providerCred);
+    expect(result['GITHUB_TOKEN']).toBe(githubToken);
+  });
+
+  it('returns only panel secrets when agent has no context secrets', () => {
+    const panelCred = staticSecret('sk-panel-key');
+    const agent = makeAgent();
+
+    const result = liftAgentContextSecrets(agent, { ANTHROPIC_API_KEY: panelCred });
+
+    expect(result).toEqual({ ANTHROPIC_API_KEY: panelCred });
+  });
+
+  it('does not mutate agent or panelSecrets', () => {
+    const providerCred = staticSecret('sk-provider-key');
+    const panelSecrets: Record<string, SecretObject> = { GITHUB_TOKEN: staticSecret('ghp') };
+    const agent = makeAgent({ ANTHROPIC_API_KEY: providerCred });
+    const originalContext = { ...(agent.agent_context as AgentContext & { secrets: Record<string, SecretObject> }).secrets };
+    const originalPanel = { ...panelSecrets };
+
+    liftAgentContextSecrets(agent, panelSecrets);
+
+    expect((agent.agent_context as AgentContext & { secrets: Record<string, SecretObject> }).secrets).toEqual(originalContext);
+    expect(panelSecrets).toEqual(originalPanel);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,7 @@ export { ACP_PROVIDERS, ACP_SETTINGS_KEYS, getAcpProvider } from './models/acp';
 export type { ACPModelOption, ACPProviderInfo, ACPProviderKey } from './models/acp';
 
 // Conversation models
+export { liftAgentContextSecrets } from './models/conversation';
 export type {
   ConversationInfo,
   ACPAgentConfig,

--- a/src/models/conversation.ts
+++ b/src/models/conversation.ts
@@ -9,6 +9,7 @@ import {
   ConfirmationPolicyBase,
   ConversationStats,
   AgentBase,
+  AgentContext,
   Event,
   EventPage,
   Message,
@@ -90,6 +91,8 @@ export interface CreateConversationRequest {
   workspace: Record<string, unknown>;
   hook_config?: HookConfig | null;
   user_id?: string | null;
+  /** Secrets seeded into the conversation's secret_registry at init. */
+  secrets?: Record<string, SecretObject>;
 }
 
 export interface CreateACPConversationRequest {
@@ -100,6 +103,8 @@ export interface CreateACPConversationRequest {
   workspace: Record<string, unknown>;
   hook_config?: HookConfig | null;
   user_id?: string | null;
+  /** Secrets seeded into the conversation's secret_registry at init. */
+  secrets?: Record<string, SecretObject>;
 }
 
 export interface GenerateTitleRequest {
@@ -208,3 +213,27 @@ export interface AgentResponseResult {
 
 export type ConversationEvent = Event;
 export type ConversationEventPage = EventPage;
+
+/**
+ * Lift secrets from an agent's context into the top-level `request.secrets` field.
+ *
+ * Mirrors Python SDK's `_start_request_kwargs()` behavior: if the agent carries
+ * `agent_context.secrets`, they are promoted so the agent-server seeds
+ * `secret_registry` from them at conversation init rather than relying on the
+ * `_start_acp_server()` drain.
+ *
+ * Merge order: `agentContextSecrets` first, then `panelSecrets` override —
+ * mirrors SDK: `{**provider_secrets, **existing}` where panel/existing wins.
+ *
+ * @param agent - The agent whose `agent_context.secrets` to lift.
+ * @param panelSecrets - User-configured secrets that take priority over agent creds.
+ * @returns Merged secrets dict suitable for `StartConversationRequest.secrets`.
+ */
+export function liftAgentContextSecrets(
+  agent: AgentBase,
+  panelSecrets?: Record<string, SecretObject>
+): Record<string, SecretObject> {
+  const ctx = agent.agent_context as AgentContext | null | undefined;
+  const contextSecrets = (ctx?.secrets as Record<string, SecretObject> | undefined) ?? {};
+  return { ...contextSecrets, ...(panelSecrets ?? {}) };
+}


### PR DESCRIPTION
## Summary

- Adds `liftAgentContextSecrets(agent, panelSecrets?)` — TypeScript equivalent of Python SDK's `_start_request_kwargs()` that lifts `agent.agent_context.secrets` into top-level `request.secrets`
- Adds typed `secrets?: Record<string, SecretObject>` field to `CreateConversationRequest` and `CreateACPConversationRequest`
- 7 unit tests covering merge order, null context, no-mutation

## Background

Python SDK callers go through `ConversationSettings.create_request()` → `_start_request_kwargs()`, which lifts `agent_context.secrets` into `request.secrets`. The agent-server then seeds `secret_registry` from `request.secrets` at conversation init.

TypeScript callers (canvas) build `StartConversationRequest` manually and have no equivalent lift. Provider credentials from `agent_context.secrets` therefore bypass `secret_registry` and reach the ACP subprocess only via the `_start_acp_server()` drain. The drain is a workaround that prevents the drain from being removed (agent-canvas#1039 task 2).

This utility closes that gap: callers pass the result of `liftAgentContextSecrets(agent, panelSecrets)` as `request.secrets`, making the TypeScript path symmetric with Python.

Merge order: agent context secrets first, panel secrets override — mirrors SDK's `{**provider_secrets, **existing}` in `ACPAgentSettings.create_agent()` so panel always wins when keys conflict.

## Related

- Closes half of [agent-canvas#1039](https://github.com/OpenHands/agent-canvas/issues/1039) task 8 (the typescript-client side)
- Canvas follow-up will wire this into `buildStartConversationRequest`
- After canvas is updated, the drain in `_start_acp_server()` can be dropped (task 2)

## Test plan

- [x] `npm run build` / `tsc --noEmit` clean
- [x] 7 unit tests pass: empty context, null context, lift only, panel wins on conflict, non-conflicting merge, panel only, no-mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)