### PR TITLE
refactor: curate ACP model registry — current generations only, re-sync mirror

### DIFF
--- a/scripts/check-acp-drift.py
+++ b/scripts/check-acp-drift.py
@@ -22,7 +22,9 @@ import sys
 
 
 def _normalize(value):
-    """Coerce tuples to lists and dataclasses to dicts; recurse."""
+    """Coerce tuples to lists and dataclasses/pydantic models to dicts; recurse."""
+    if hasattr(value, "model_dump"):  # pydantic models (e.g. ACPFileSecretSpec)
+        return _normalize(value.model_dump(mode="json"))
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return _normalize(dataclasses.asdict(value))
     if isinstance(value, dict):

--- a/src/models/acp-providers.json
+++ b/src/models/acp-providers.json
@@ -59,7 +59,7 @@
         "label": "Opus (plan) + Sonnet (execute)"
       }
     ],
-    "default_model": "claude-opus-4-7",
+    "default_model": "claude-opus-4-8",
     "supports_runtime_model_switch": true,
     "file_secrets": [],
     "binary_name": "claude-agent-acp",

--- a/src/models/acp-providers.json
+++ b/src/models/acp-providers.json
@@ -11,6 +11,14 @@
     "session_meta_key": "claudeCode",
     "available_models": [
       {
+        "id": "claude-fable-5",
+        "label": "Claude Fable 5"
+      },
+      {
+        "id": "claude-opus-4-8",
+        "label": "Claude Opus 4.8"
+      },
+      {
         "id": "claude-opus-4-7",
         "label": "Claude Opus 4.7"
       },

--- a/src/models/acp-providers.json
+++ b/src/models/acp-providers.json
@@ -19,36 +19,12 @@
         "label": "Claude Opus 4.8"
       },
       {
-        "id": "claude-opus-4-7",
-        "label": "Claude Opus 4.7"
-      },
-      {
-        "id": "claude-opus-4-6",
-        "label": "Claude Opus 4.6"
-      },
-      {
         "id": "opus[1m]",
         "label": "Claude Opus (1M)"
       },
       {
-        "id": "claude-opus-4-5",
-        "label": "Claude Opus 4.5"
-      },
-      {
-        "id": "claude-opus-4-1-20250805",
-        "label": "Claude Opus 4.1"
-      },
-      {
         "id": "claude-sonnet-4-6",
         "label": "Claude Sonnet 4.6"
-      },
-      {
-        "id": "sonnet[1m]",
-        "label": "Claude Sonnet (1M)"
-      },
-      {
-        "id": "claude-sonnet-4-5",
-        "label": "Claude Sonnet 4.5"
       },
       {
         "id": "claude-haiku-4-5",
@@ -91,22 +67,6 @@
       {
         "id": "gpt-5.5/xhigh",
         "label": "GPT-5.5 (xhigh)"
-      },
-      {
-        "id": "gpt-5.4/low",
-        "label": "GPT-5.4 (low)"
-      },
-      {
-        "id": "gpt-5.4/medium",
-        "label": "GPT-5.4 (medium)"
-      },
-      {
-        "id": "gpt-5.4/high",
-        "label": "GPT-5.4 (high)"
-      },
-      {
-        "id": "gpt-5.4/xhigh",
-        "label": "GPT-5.4 (xhigh)"
       },
       {
         "id": "gpt-5.4-mini/low",

--- a/src/models/acp-providers.json
+++ b/src/models/acp-providers.json
@@ -2,87 +2,193 @@
   "claude-code": {
     "key": "claude-code",
     "display_name": "Claude Code",
-    "default_command": ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+    "default_command": ["npx", "-y", "@agentclientprotocol/claude-agent-acp@0.30.0"],
     "api_key_env_var": "ANTHROPIC_API_KEY",
     "base_url_env_var": "ANTHROPIC_BASE_URL",
     "default_session_mode": "bypassPermissions",
     "agent_name_patterns": ["claude-agent"],
     "supports_set_session_model": false,
-    "supports_runtime_model_switch": true,
     "session_meta_key": "claudeCode",
     "available_models": [
-      { "id": "claude-opus-4-7", "label": "Claude Opus 4.7" },
-      { "id": "claude-opus-4-6", "label": "Claude Opus 4.6" },
-      { "id": "opus[1m]", "label": "Claude Opus (1M)" },
-      { "id": "claude-opus-4-5", "label": "Claude Opus 4.5" },
-      { "id": "claude-opus-4-1-20250805", "label": "Claude Opus 4.1" },
-      { "id": "claude-sonnet-4-6", "label": "Claude Sonnet 4.6" },
-      { "id": "sonnet[1m]", "label": "Claude Sonnet (1M)" },
-      { "id": "claude-sonnet-4-5", "label": "Claude Sonnet 4.5" },
-      { "id": "claude-haiku-4-5", "label": "Claude Haiku 4.5" },
-      { "id": "opusplan", "label": "Opus (plan) + Sonnet (execute)" }
+      {
+        "id": "claude-opus-4-7",
+        "label": "Claude Opus 4.7"
+      },
+      {
+        "id": "claude-opus-4-6",
+        "label": "Claude Opus 4.6"
+      },
+      {
+        "id": "opus[1m]",
+        "label": "Claude Opus (1M)"
+      },
+      {
+        "id": "claude-opus-4-5",
+        "label": "Claude Opus 4.5"
+      },
+      {
+        "id": "claude-opus-4-1-20250805",
+        "label": "Claude Opus 4.1"
+      },
+      {
+        "id": "claude-sonnet-4-6",
+        "label": "Claude Sonnet 4.6"
+      },
+      {
+        "id": "sonnet[1m]",
+        "label": "Claude Sonnet (1M)"
+      },
+      {
+        "id": "claude-sonnet-4-5",
+        "label": "Claude Sonnet 4.5"
+      },
+      {
+        "id": "claude-haiku-4-5",
+        "label": "Claude Haiku 4.5"
+      },
+      {
+        "id": "opusplan",
+        "label": "Opus (plan) + Sonnet (execute)"
+      }
     ],
-    "default_model": "claude-opus-4-7"
+    "default_model": "claude-opus-4-7",
+    "supports_runtime_model_switch": true,
+    "file_secrets": [],
+    "binary_name": "claude-agent-acp",
+    "data_dir_env_var": "CLAUDE_CONFIG_DIR"
   },
   "codex": {
     "key": "codex",
     "display_name": "Codex",
-    "default_command": ["npx", "-y", "@zed-industries/codex-acp"],
+    "default_command": ["npx", "-y", "@zed-industries/codex-acp@0.15.0"],
     "api_key_env_var": "OPENAI_API_KEY",
     "base_url_env_var": "OPENAI_BASE_URL",
     "default_session_mode": "full-access",
     "agent_name_patterns": ["codex-acp"],
     "supports_set_session_model": true,
-    "supports_runtime_model_switch": true,
     "session_meta_key": null,
     "available_models": [
-      { "id": "gpt-5.5/low", "label": "GPT-5.5 (low)" },
-      { "id": "gpt-5.5/medium", "label": "GPT-5.5 (medium)" },
-      { "id": "gpt-5.5/high", "label": "GPT-5.5 (high)" },
-      { "id": "gpt-5.5/xhigh", "label": "GPT-5.5 (xhigh)" },
-      { "id": "gpt-5.4/low", "label": "GPT-5.4 (low)" },
-      { "id": "gpt-5.4/medium", "label": "GPT-5.4 (medium)" },
-      { "id": "gpt-5.4/high", "label": "GPT-5.4 (high)" },
-      { "id": "gpt-5.4/xhigh", "label": "GPT-5.4 (xhigh)" },
-      { "id": "gpt-5.4-mini/low", "label": "GPT-5.4 Mini (low)" },
-      { "id": "gpt-5.4-mini/medium", "label": "GPT-5.4 Mini (medium)" },
-      { "id": "gpt-5.4-mini/high", "label": "GPT-5.4 Mini (high)" },
-      { "id": "gpt-5.4-mini/xhigh", "label": "GPT-5.4 Mini (xhigh)" },
-      { "id": "gpt-5.3-codex/low", "label": "GPT-5.3 Codex (low)" },
-      { "id": "gpt-5.3-codex/medium", "label": "GPT-5.3 Codex (medium)" },
-      { "id": "gpt-5.3-codex/high", "label": "GPT-5.3 Codex (high)" },
-      { "id": "gpt-5.3-codex/xhigh", "label": "GPT-5.3 Codex (xhigh)" },
-      { "id": "gpt-5.2/low", "label": "GPT-5.2 (low)" },
-      { "id": "gpt-5.2/medium", "label": "GPT-5.2 (medium)" },
-      { "id": "gpt-5.2/high", "label": "GPT-5.2 (high)" },
-      { "id": "gpt-5.2/xhigh", "label": "GPT-5.2 (xhigh)" }
+      {
+        "id": "gpt-5.5/low",
+        "label": "GPT-5.5 (low)"
+      },
+      {
+        "id": "gpt-5.5/medium",
+        "label": "GPT-5.5 (medium)"
+      },
+      {
+        "id": "gpt-5.5/high",
+        "label": "GPT-5.5 (high)"
+      },
+      {
+        "id": "gpt-5.5/xhigh",
+        "label": "GPT-5.5 (xhigh)"
+      },
+      {
+        "id": "gpt-5.4/low",
+        "label": "GPT-5.4 (low)"
+      },
+      {
+        "id": "gpt-5.4/medium",
+        "label": "GPT-5.4 (medium)"
+      },
+      {
+        "id": "gpt-5.4/high",
+        "label": "GPT-5.4 (high)"
+      },
+      {
+        "id": "gpt-5.4/xhigh",
+        "label": "GPT-5.4 (xhigh)"
+      },
+      {
+        "id": "gpt-5.4-mini/low",
+        "label": "GPT-5.4 Mini (low)"
+      },
+      {
+        "id": "gpt-5.4-mini/medium",
+        "label": "GPT-5.4 Mini (medium)"
+      },
+      {
+        "id": "gpt-5.4-mini/high",
+        "label": "GPT-5.4 Mini (high)"
+      },
+      {
+        "id": "gpt-5.4-mini/xhigh",
+        "label": "GPT-5.4 Mini (xhigh)"
+      }
     ],
-    "default_model": "gpt-5.5/medium"
+    "default_model": "gpt-5.5/medium",
+    "supports_runtime_model_switch": true,
+    "file_secrets": [
+      {
+        "secret_name": "CODEX_AUTH_JSON",
+        "filename": "auth.json",
+        "env_var": "CODEX_HOME",
+        "subdir": "codex",
+        "env_points_to": "dir",
+        "warn_if_unset": []
+      }
+    ],
+    "binary_name": "codex-acp",
+    "data_dir_env_var": "CODEX_HOME"
   },
   "gemini-cli": {
     "key": "gemini-cli",
     "display_name": "Gemini CLI",
-    "default_command": ["npx", "-y", "@google/gemini-cli", "--acp"],
+    "default_command": ["npx", "-y", "@google/gemini-cli@0.38.0", "--acp"],
     "api_key_env_var": "GEMINI_API_KEY",
     "base_url_env_var": "GEMINI_BASE_URL",
     "default_session_mode": "yolo",
     "agent_name_patterns": ["gemini-cli"],
     "supports_set_session_model": true,
-    "supports_runtime_model_switch": true,
     "session_meta_key": null,
     "available_models": [
-      { "id": "auto-gemini-3", "label": "Auto (Gemini 3)" },
-      { "id": "auto-gemini-2.5", "label": "Auto (Gemini 2.5)" },
-      { "id": "gemini-3.1-pro-preview", "label": "Gemini 3.1 Pro (preview)" },
-      { "id": "gemini-3-flash-preview", "label": "Gemini 3 Flash (preview)" },
+      {
+        "id": "auto-gemini-3",
+        "label": "Auto (Gemini 3)"
+      },
+      {
+        "id": "auto-gemini-2.5",
+        "label": "Auto (Gemini 2.5)"
+      },
+      {
+        "id": "gemini-3.1-pro-preview",
+        "label": "Gemini 3.1 Pro (preview)"
+      },
+      {
+        "id": "gemini-3-flash-preview",
+        "label": "Gemini 3 Flash (preview)"
+      },
       {
         "id": "gemini-3.1-flash-lite-preview",
         "label": "Gemini 3.1 Flash Lite (preview)"
       },
-      { "id": "gemini-2.5-pro", "label": "Gemini 2.5 Pro" },
-      { "id": "gemini-2.5-flash", "label": "Gemini 2.5 Flash" },
-      { "id": "gemini-2.5-flash-lite", "label": "Gemini 2.5 Flash Lite" }
+      {
+        "id": "gemini-2.5-pro",
+        "label": "Gemini 2.5 Pro"
+      },
+      {
+        "id": "gemini-2.5-flash",
+        "label": "Gemini 2.5 Flash"
+      },
+      {
+        "id": "gemini-2.5-flash-lite",
+        "label": "Gemini 2.5 Flash Lite"
+      }
     ],
-    "default_model": "auto-gemini-2.5"
+    "default_model": "auto-gemini-2.5",
+    "supports_runtime_model_switch": true,
+    "file_secrets": [
+      {
+        "secret_name": "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+        "filename": "gcloud-credentials.json",
+        "env_var": "GOOGLE_APPLICATION_CREDENTIALS",
+        "subdir": "gemini-cli",
+        "env_points_to": "file",
+        "warn_if_unset": ["GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"]
+      }
+    ],
+    "binary_name": "gemini",
+    "data_dir_env_var": "HOME"
   }
 }

--- a/src/models/acp.ts
+++ b/src/models/acp.ts
@@ -34,6 +34,26 @@ export interface ACPModelOption {
 }
 
 /**
+ * Declarative spec for one file-content credential a provider can consume
+ * (e.g. Codex `auth.json`). Mirrors
+ * `openhands.sdk.settings.acp_providers.ACPFileSecretSpec` field-for-field.
+ */
+export interface ACPFileSecretSpec {
+  /** Reserved secret name whose value is the file's content. */
+  readonly secret_name: string;
+  /** Filename the secret is materialised as. */
+  readonly filename: string;
+  /** Env var pointed at the materialised file (or its directory). */
+  readonly env_var: string;
+  /** Per-provider subdirectory the file lives in. */
+  readonly subdir: string;
+  /** Whether `env_var` points at the file itself or its directory. */
+  readonly env_points_to: 'file' | 'dir';
+  /** Companion env vars the server warns about when missing. */
+  readonly warn_if_unset: readonly string[];
+}
+
+/**
  * Immutable metadata record for one built-in ACP provider. Mirrors
  * `openhands.sdk.settings.acp_providers.ACPProviderInfo` field-for-field.
  */
@@ -72,6 +92,15 @@ export interface ACPProviderInfo {
    * or `null` to let the ACP server pick its own default.
    */
   readonly default_model: string | null;
+  /** File-content credentials the agent server can materialise on disk. */
+  readonly file_secrets: readonly ACPFileSecretSpec[];
+  /**
+   * Bare executable name of the provider's pinned CLI, or `null`. The agent
+   * server prefers this binary over the `npx` fallback when it is on PATH.
+   */
+  readonly binary_name: string | null;
+  /** Env var that relocates the provider's data/config directory, or `null`. */
+  readonly data_dir_env_var: string | null;
 }
 
 export const ACP_PROVIDERS: Readonly<Record<ACPProviderKey, ACPProviderInfo>> =


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

- [ ] A human has tested these changes.

---

## Why

Mirrors OpenHands/software-agent-sdk#3653 (issue software-agent-sdk#3651): an end-to-end audit of every registry model against the pinned CLIs found `gpt-5.3-codex/*` and `gpt-5.2/*` broken on codex-acp 0.15.0 — the CLI no longer advertises either family in `session/new` `availableModels`, and prompting on them fails with HTTP 400 `model is not supported when using Codex with a ChatGPT account`, surfaced as the opaque `-32603`.

While updating the mirror, the drift check turned out to be latently broken: the SDK's `ACPProviderInfo` gained `file_secrets` / `binary_name` / `data_dir_env_var` and version-pinned `npx` commands since the mirror was last synced, and `check-acp-drift.py` crashes on the pydantic `ACPFileSecretSpec` entries (`TypeError: Object of type ACPFileSecretSpec is not JSON serializable`). Any PR here would fail the `validate-acp-providers` job regardless of its content.

## Summary

- Trim both lists to current generations (mirrors the SDK PR): Claude → `claude-fable-5`, `claude-opus-4-8`, `opus[1m]`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `opusplan`; Codex → `gpt-5.5/*` + `gpt-5.4-mini/*`.
- Add `claude-fable-5` and `claude-opus-4-8` to the claude-code `available_models` (verified end-to-end on the pinned CLI; `claude-mythos-5` is access-gated and rejected, not added); `default_model` bumped to `claude-opus-4-8`.
- Remove `gpt-5.3-codex/{low,medium,high,xhigh}` and `gpt-5.2/{low,medium,high,xhigh}` from the codex `available_models` in `src/models/acp-providers.json`.
- Re-sync the mirror field-for-field with SDK `ACP_PROVIDERS`: pinned `default_command` versions, `file_secrets`, `binary_name`, `data_dir_env_var`.
- Type the new fields in `src/models/acp.ts` (`ACPFileSecretSpec`, three new `ACPProviderInfo` members).
- Fix `scripts/check-acp-drift.py` `_normalize` to handle pydantic models.

## Issue Number

OpenHands/software-agent-sdk#3651

## Dependency

⚠️ The `validate-acp-providers` job compares against SDK **main** and will stay red until OpenHands/software-agent-sdk#3653 merges. Verified green locally against that branch:

```
$ PYTHONPATH=<sdk-branch>/openhands-sdk python3 scripts/check-acp-drift.py
OK: src/models/acp-providers.json matches openhands-sdk (3 providers).
```

## How to Test

- `npm run build && npm test` → 213 passed; `npm run format:check` and `npm run lint` clean (0 errors).
- After sdk#3653 merges, re-run the `validate-acp-providers` job — it should pass; on current SDK main it crashes on `ACPFileSecretSpec` even before diffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
