### PR TITLE
fix: mirror claude-code supports_set_session_model=true

### DIFF
--- a/src/models/acp-providers.json
+++ b/src/models/acp-providers.json
@@ -7,7 +7,7 @@
     "base_url_env_var": "ANTHROPIC_BASE_URL",
     "default_session_mode": "bypassPermissions",
     "agent_name_patterns": ["claude-agent"],
-    "supports_set_session_model": false,
+    "supports_set_session_model": true,
     "session_meta_key": "claudeCode",
     "available_models": [
       {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

- [ ] A human has tested these changes.

---

## Why

Mirrors OpenHands/software-agent-sdk#3655: claude-agent-acp 0.30.0 silently ignores the `_meta`-based initial model selection (software-agent-sdk#3654), so the SDK now applies the claude-code initial model via `session/set_model` and flips `supports_set_session_model` to `true` in the registry. This repo's JSON mirror must match field-for-field or the `validate-acp-providers` drift job blocks all PRs.

## Summary

- `claude-code.supports_set_session_model`: `false` → `true` in `src/models/acp-providers.json` (one line; codex/gemini untouched).

## Issue Number

OpenHands/software-agent-sdk#3654

## How to Test

- `npm test` → all suites pass.
- `validate-acp-providers` compares against SDK **main** and stays red until OpenHands/software-agent-sdk#3655 merges; verified green locally against that branch:

```
$ PYTHONPATH=<sdk-branch>/openhands-sdk python3 scripts/check-acp-drift.py
OK: src/models/acp-providers.json matches openhands-sdk (3 providers).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
