### PR TITLE
[AgentProfile][ts-client] Test ACP provider credential descriptors + re-sync claude-code set_session_model mirror

### DIFF
--- a/src/__tests__/acp-providers.test.ts
+++ b/src/__tests__/acp-providers.test.ts
@@ -1,0 +1,96 @@
+import { ACP_PROVIDERS, getAcpProvider } from '../index';
+import type { ACPProviderKey } from '../index';
+
+/**
+ * The canvas ACP authentication section (#3728) renders provider-specific
+ * credential forms by reading the descriptor fields off {@link ACP_PROVIDERS}
+ * rather than hardcoding provider lists. These tests lock in that every
+ * built-in provider exposes the credential metadata that UI relies on:
+ * `api_key_env_var`, `base_url_env_var`, and `file_secrets`.
+ */
+describe('ACP provider credential descriptors', () => {
+  const KEYS: ACPProviderKey[] = ['claude-code', 'codex', 'gemini-cli'];
+
+  it('exposes an entry for each built-in provider', () => {
+    for (const key of KEYS) {
+      expect(ACP_PROVIDERS[key]).toBeDefined();
+      expect(ACP_PROVIDERS[key].key).toBe(key);
+    }
+  });
+
+  it('defines the credential descriptor fields on every provider', () => {
+    for (const key of KEYS) {
+      const provider = ACP_PROVIDERS[key];
+      // api_key_env_var / base_url_env_var are `string | null` — present (not
+      // undefined) on every provider so callers can branch on the value.
+      expect(provider).toHaveProperty('api_key_env_var');
+      expect(provider).toHaveProperty('base_url_env_var');
+      expect(Array.isArray(provider.file_secrets)).toBe(true);
+    }
+  });
+
+  it.each<[ACPProviderKey, string, string]>([
+    ['claude-code', 'ANTHROPIC_API_KEY', 'ANTHROPIC_BASE_URL'],
+    ['codex', 'OPENAI_API_KEY', 'OPENAI_BASE_URL'],
+    ['gemini-cli', 'GEMINI_API_KEY', 'GEMINI_BASE_URL'],
+  ])('%s declares its api_key/base_url env vars', (key, apiKeyEnvVar, baseUrlEnvVar) => {
+    const provider = ACP_PROVIDERS[key];
+    expect(provider.api_key_env_var).toBe(apiKeyEnvVar);
+    expect(provider.base_url_env_var).toBe(baseUrlEnvVar);
+  });
+
+  describe('file_secrets', () => {
+    it('claude-code authenticates via env var only (no file secrets)', () => {
+      expect(ACP_PROVIDERS['claude-code'].file_secrets).toEqual([]);
+    });
+
+    it('codex declares its ChatGPT auth.json file secret', () => {
+      const fileSecrets = ACP_PROVIDERS['codex'].file_secrets;
+      expect(fileSecrets).toHaveLength(1);
+      expect(fileSecrets[0]).toMatchObject({
+        secret_name: 'CODEX_AUTH_JSON',
+        filename: 'auth.json',
+        env_var: 'CODEX_HOME',
+      });
+    });
+
+    it('gemini-cli declares its Vertex SA credential file secret', () => {
+      const fileSecrets = ACP_PROVIDERS['gemini-cli'].file_secrets;
+      expect(fileSecrets).toHaveLength(1);
+      expect(fileSecrets[0]).toMatchObject({
+        secret_name: 'GOOGLE_APPLICATION_CREDENTIALS_JSON',
+        filename: 'gcloud-credentials.json',
+        env_var: 'GOOGLE_APPLICATION_CREDENTIALS',
+      });
+    });
+
+    it('every file secret carries the descriptor fields the canvas renders from', () => {
+      for (const key of KEYS) {
+        for (const spec of ACP_PROVIDERS[key].file_secrets) {
+          expect(typeof spec.secret_name).toBe('string');
+          expect(spec.secret_name.length).toBeGreaterThan(0);
+          expect(typeof spec.filename).toBe('string');
+          expect(spec.filename.length).toBeGreaterThan(0);
+          expect(typeof spec.env_var).toBe('string');
+          expect(spec.env_var.length).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe('getAcpProvider', () => {
+    it('returns the descriptor (with credential fields) for a known key', () => {
+      const provider = getAcpProvider('codex');
+      expect(provider).not.toBeNull();
+      expect(provider?.api_key_env_var).toBe('OPENAI_API_KEY');
+      expect(provider?.base_url_env_var).toBe('OPENAI_BASE_URL');
+    });
+
+    it('returns null for the custom discriminator and unknown / falsy keys', () => {
+      expect(getAcpProvider('custom')).toBeNull();
+      expect(getAcpProvider('nonexistent')).toBeNull();
+      expect(getAcpProvider(null)).toBeNull();
+      expect(getAcpProvider(undefined)).toBeNull();
+    });
+  });
+});

--- a/src/models/acp-providers.json
+++ b/src/models/acp-providers.json
@@ -7,7 +7,7 @@
     "base_url_env_var": "ANTHROPIC_BASE_URL",
     "default_session_mode": "bypassPermissions",
     "agent_name_patterns": ["claude-agent"],
-    "supports_set_session_model": false,
+    "supports_set_session_model": true,
     "session_meta_key": "claudeCode",
     "available_models": [
       {


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

- [x] A human has tested these changes.

---

## Why

Part of the AgentProfile epic (OpenHands/software-agent-sdk#3713), Phase 3 —
this is the **"ACP provider descriptor extension"** slice of
OpenHands/software-agent-sdk#3722. The canvas ACP authentication section
(sdk#3728) renders provider-specific credential forms by reading credential
metadata off `ACP_PROVIDERS` (`api_key_env_var`, `base_url_env_var`,
`file_secrets`) instead of hardcoding provider lists.

Those descriptor fields **already exist** on `ACPProviderInfo` and are
populated for all three providers — they landed with the registry mirror
work (#173/#187/#205), which post-dates the issue text (the issue still
references the pre-mirror `src/utils/acp.ts`; the registry now lives in
`src/models/acp.ts`). Their shape is a superset of the issue's request
(`string | null` plus a richer `file_secrets` mirroring the SDK
field-for-field), so changing them to optional `?: string` would be a
regression. The remaining gaps were: **no test** locking the metadata in,
and a **drifted mirror field** that left CI red on `main`.

## Summary

- Add `src/__tests__/acp-providers.test.ts` — asserts every built-in
  provider (claude-code, codex, gemini-cli) exposes `api_key_env_var`,
  `base_url_env_var`, and `file_secrets`, checks each provider's expected
  env-var values and file-secret descriptors, and covers `getAcpProvider`
  (known key, `custom`, unknown, and falsy inputs).
- Re-sync the one drifted mirror field: claude-code
  `supports_set_session_model` `false → true` to match SDK `main`, which
  flipped it (sdk#3654) after claude-agent-acp 0.30.0 was found to ignore
  session-`_meta` model selection. The `validate-acp-providers` drift check
  was red on `main` until this.

## Issue Number

OpenHands/software-agent-sdk#3722 (epic OpenHands/software-agent-sdk#3713)

## How to Test

Locally, against SDK `main` (what CI's `validate-acp-providers` pins to):

```
npm run build         # tsc clean
npm run lint          # 0 errors
npm run format:check  # clean
npm run test:coverage # 224 passed (13 suites), incl. 11 new acp-providers tests

pip install -r scripts/requirements-acp-check.txt
python scripts/check-acp-drift.py
# OK: src/models/acp-providers.json matches openhands-sdk (3 providers).
```

## Type

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Purely additive: no public type or interface change — `ACPProviderInfo`
  already carried the credential fields; this only adds test coverage and a
  one-line mirror re-sync.
- The CI `security` job (`npm audit`) is failing on `main` too — pre-existing
  transitive-dependency advisories (jest/babel/`ws`); this PR touches neither
  `package.json` nor `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
