### PR TITLE
[AgentProfile][ts-client] AgentProfile types + client + deriveSwitchPlan

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -73,8 +73,14 @@ describe('Auxiliary API clients', () => {
     it('listAgentProfiles fetches /api/agent-profiles', async () => {
       const payload = {
         profiles: [
-          { id: 'uuid-1', name: 'default', agent_kind: 'openhands', revision: 0,
-            llm_profile_ref: 'gpt-4o', mcp_server_refs: null },
+          {
+            id: 'uuid-1',
+            name: 'default',
+            agent_kind: 'openhands',
+            revision: 0,
+            llm_profile_ref: 'gpt-4o',
+            mcp_server_refs: null,
+          },
         ],
         active_agent_profile_id: 'uuid-1',
       };
@@ -117,10 +123,13 @@ describe('Auxiliary API clients', () => {
 
     it('saveAgentProfile posts to /api/agent-profiles/{name}', async () => {
       global.fetch = jest.fn().mockResolvedValue(
-        new Response(JSON.stringify({ name: 'myprofile', message: "Agent profile 'myprofile' saved" }), {
-          status: 201,
-          headers: { 'content-type': 'application/json' },
-        })
+        new Response(
+          JSON.stringify({ name: 'myprofile', message: "Agent profile 'myprofile' saved" }),
+          {
+            status: 201,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
       ) as typeof fetch;
 
       const client = new AgentProfilesClient({ host: 'http://example.com' });
@@ -138,10 +147,13 @@ describe('Auxiliary API clients', () => {
 
     it('deleteAgentProfile sends DELETE to /api/agent-profiles/{name}', async () => {
       global.fetch = jest.fn().mockResolvedValue(
-        new Response(JSON.stringify({ name: 'myprofile', message: "Agent profile 'myprofile' deleted" }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        })
+        new Response(
+          JSON.stringify({ name: 'myprofile', message: "Agent profile 'myprofile' deleted" }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
       ) as typeof fetch;
 
       const client = new AgentProfilesClient({ host: 'http://example.com' });
@@ -156,7 +168,7 @@ describe('Auxiliary API clients', () => {
 
     it('renameAgentProfile posts new_name', async () => {
       global.fetch = jest.fn().mockResolvedValue(
-        new Response(JSON.stringify({ name: 'newname', message: "renamed" }), {
+        new Response(JSON.stringify({ name: 'newname', message: 'renamed' }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         })
@@ -171,12 +183,14 @@ describe('Auxiliary API clients', () => {
 
     it('activateAgentProfile posts to /{profileId}/activate', async () => {
       const profileId = 'uuid-abc-123';
-      global.fetch = jest.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({ id: profileId, message: 'activated', agent_settings_applied: false }),
-          { status: 200, headers: { 'content-type': 'application/json' } }
-        )
-      ) as typeof fetch;
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ id: profileId, message: 'activated', agent_settings_applied: false }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        ) as typeof fetch;
 
       const client = new AgentProfilesClient({ host: 'http://example.com' });
       const result = await client.activateAgentProfile(profileId);

--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -136,13 +136,15 @@ describe('Auxiliary API clients', () => {
       const result = await client.saveAgentProfile('myprofile', {
         agent_kind: 'openhands',
         llm_profile_ref: 'gpt-4o',
-      } as Record<string, unknown>);
+      });
 
       expect(result.name).toBe('myprofile');
       expect(global.fetch).toHaveBeenCalledWith(
         'http://example.com/api/agent-profiles/myprofile',
         expect.objectContaining({ method: 'POST' })
       );
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body as string);
+      expect(body).toEqual({ agent_kind: 'openhands', llm_profile_ref: 'gpt-4o' });
     });
 
     it('deleteAgentProfile sends DELETE to /api/agent-profiles/{name}', async () => {

--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -10,6 +10,7 @@ import {
   Workspace,
 } from '../index';
 import {
+  AgentProfilesClient,
   AgentServerVersionError,
   ApiKeysClient,
   BashClient,
@@ -47,11 +48,14 @@ describe('Auxiliary API clients', () => {
     expect(manager.server).toBeInstanceOf(ServerClient);
     expect(manager.skills).toBeInstanceOf(SkillsClient);
     expect(manager.profiles).toBeInstanceOf(ProfilesClient);
+    expect(manager.agentProfiles).toBeInstanceOf(AgentProfilesClient);
     expect(manager.metaProfiles).toBeInstanceOf(MetaProfilesClient);
     expect(manager.server.host).toBe('http://example.com');
     expect(manager.server.apiKey).toBe('secret');
     expect(manager.profiles.host).toBe('http://example.com');
     expect(manager.profiles.apiKey).toBe('secret');
+    expect(manager.agentProfiles.host).toBe('http://example.com');
+    expect(manager.agentProfiles.apiKey).toBe('secret');
     expect(manager.metaProfiles.host).toBe('http://example.com');
     expect(manager.metaProfiles.apiKey).toBe('secret');
     expect(manager.files).toBeInstanceOf(FileClient);
@@ -63,6 +67,161 @@ describe('Auxiliary API clients', () => {
     expect(manager.hooks).toBeInstanceOf(HooksClient);
     expect(manager.mcp).toBeInstanceOf(MCPClient);
     expect(manager.cloudProxy).toBeInstanceOf(CloudProxyClient);
+  });
+
+  describe('AgentProfilesClient', () => {
+    it('listAgentProfiles fetches /api/agent-profiles', async () => {
+      const payload = {
+        profiles: [
+          { id: 'uuid-1', name: 'default', agent_kind: 'openhands', revision: 0,
+            llm_profile_ref: 'gpt-4o', mcp_server_refs: null },
+        ],
+        active_agent_profile_id: 'uuid-1',
+      };
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      ) as typeof fetch;
+
+      const client = new AgentProfilesClient({ host: 'http://example.com', apiKey: 'k' });
+      const result = await client.listAgentProfiles();
+
+      expect(result.active_agent_profile_id).toBe('uuid-1');
+      expect(result.profiles).toHaveLength(1);
+      expect(result.profiles[0].name).toBe('default');
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com/api/agent-profiles',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('getAgentProfile sets X-Expose-Secrets header when requested', async () => {
+      const payload = { name: 'default', profile: { agent_kind: 'openhands' } };
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      ) as typeof fetch;
+
+      const client = new AgentProfilesClient({ host: 'http://example.com' });
+      await client.getAgentProfile('default', { exposeSecrets: 'plaintext' });
+
+      const call = (global.fetch as jest.Mock).mock.calls[0];
+      expect(call[0]).toBe('http://example.com/api/agent-profiles/default');
+      const headers = call[1]?.headers as Record<string, string>;
+      expect(headers['X-Expose-Secrets']).toBe('plaintext');
+    });
+
+    it('saveAgentProfile posts to /api/agent-profiles/{name}', async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(JSON.stringify({ name: 'myprofile', message: "Agent profile 'myprofile' saved" }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        })
+      ) as typeof fetch;
+
+      const client = new AgentProfilesClient({ host: 'http://example.com' });
+      const result = await client.saveAgentProfile('myprofile', {
+        agent_kind: 'openhands',
+        llm_profile_ref: 'gpt-4o',
+      } as Record<string, unknown>);
+
+      expect(result.name).toBe('myprofile');
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com/api/agent-profiles/myprofile',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('deleteAgentProfile sends DELETE to /api/agent-profiles/{name}', async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(JSON.stringify({ name: 'myprofile', message: "Agent profile 'myprofile' deleted" }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      ) as typeof fetch;
+
+      const client = new AgentProfilesClient({ host: 'http://example.com' });
+      const result = await client.deleteAgentProfile('myprofile');
+
+      expect(result.name).toBe('myprofile');
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com/api/agent-profiles/myprofile',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+
+    it('renameAgentProfile posts new_name', async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(JSON.stringify({ name: 'newname', message: "renamed" }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      ) as typeof fetch;
+
+      const client = new AgentProfilesClient({ host: 'http://example.com' });
+      await client.renameAgentProfile('oldname', 'newname');
+
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body as string);
+      expect(body.new_name).toBe('newname');
+    });
+
+    it('activateAgentProfile posts to /{profileId}/activate', async () => {
+      const profileId = 'uuid-abc-123';
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ id: profileId, message: 'activated', agent_settings_applied: false }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      ) as typeof fetch;
+
+      const client = new AgentProfilesClient({ host: 'http://example.com' });
+      const result = await client.activateAgentProfile(profileId);
+
+      expect(result.id).toBe(profileId);
+      expect(result.agent_settings_applied).toBe(false);
+      expect(global.fetch).toHaveBeenCalledWith(
+        `http://example.com/api/agent-profiles/${profileId}/activate`,
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('materializeAgentProfile posts to /{name}/materialize', async () => {
+      const diagnostics = {
+        agent_kind: 'openhands',
+        valid: true,
+        errors: [],
+        llm_profile_ref: 'gpt-4o',
+        llm_profile_resolved: true,
+        llm_api_key_set: true,
+        mcp_server_refs: null,
+        resolved_mcp_servers: [],
+        dangling_mcp_server_refs: [],
+        acp_api_key_secret_name: null,
+        acp_base_url_secret_name: null,
+        acp_file_secret_names: [],
+        resolved_settings: {},
+      };
+      global.fetch = jest.fn().mockResolvedValue(
+        new Response(JSON.stringify(diagnostics), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      ) as typeof fetch;
+
+      const client = new AgentProfilesClient({ host: 'http://example.com' });
+      const result = await client.materializeAgentProfile('default');
+
+      expect(result.valid).toBe(true);
+      expect(result.llm_profile_ref).toBe('gpt-4o');
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com/api/agent-profiles/default/materialize',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
   });
 
   it('Workspace exposes bash namespace', () => {

--- a/src/__tests__/derive-switch-plan.test.ts
+++ b/src/__tests__/derive-switch-plan.test.ts
@@ -1,0 +1,194 @@
+import { deriveSwitchPlan } from '../profiles/derive-switch-plan';
+import { ACP_PROVIDERS } from '../models/acp';
+import type { ACPAgentProfile, OpenHandsAgentProfile } from '../models/agent-profile';
+import type { ACPProviderInfo } from '../models/acp';
+
+const baseVerification = {
+  critic_enabled: false,
+  critic_mode: 'finish_and_message',
+  enable_iterative_refinement: false,
+  critic_threshold: 0.6,
+  max_refinement_iterations: 3,
+  critic_server_url: null,
+  critic_model_name: null,
+};
+
+const ohBase: OpenHandsAgentProfile = {
+  id: 'profile-1',
+  name: 'default',
+  revision: 0,
+  agent_kind: 'openhands',
+  llm_profile_ref: 'gpt-4o',
+  mcp_server_refs: null,
+  agent: 'CodeActAgent',
+  skills: [],
+  system_message_suffix: null,
+  condenser: {},
+  verification: baseVerification,
+  enable_sub_agents: false,
+  tool_concurrency_limit: 1,
+};
+
+const acpBase: ACPAgentProfile = {
+  id: 'profile-2',
+  name: 'claude-default',
+  revision: 0,
+  agent_kind: 'acp',
+  acp_server: 'claude-code',
+  acp_model: 'claude-sonnet-4-6',
+  acp_session_mode: null,
+  acp_prompt_timeout: 1800,
+  acp_command: null,
+  acp_args: null,
+  mcp_server_refs: null,
+};
+
+const claudeProvider: ACPProviderInfo = ACP_PROVIDERS['claude-code'];
+const codexProvider: ACPProviderInfo = ACP_PROVIDERS['codex'];
+
+describe('deriveSwitchPlan', () => {
+  describe('null snapshot', () => {
+    it('returns start-new when no snapshot', () => {
+      const plan = deriveSwitchPlan(null, ohBase, null);
+      expect(plan.action).toBe('start-new');
+    });
+
+    it('returns start-new when snapshot is undefined', () => {
+      const plan = deriveSwitchPlan(undefined, ohBase, null);
+      expect(plan.action).toBe('start-new');
+    });
+  });
+
+  describe('current', () => {
+    it('returns current when same id and revision', () => {
+      const plan = deriveSwitchPlan(ohBase, ohBase, null);
+      expect(plan.action).toBe('current');
+    });
+
+    it('returns current when ACP same id and revision', () => {
+      const plan = deriveSwitchPlan(acpBase, acpBase, claudeProvider);
+      expect(plan.action).toBe('current');
+    });
+
+    it('returns current when OpenHands content identical but different object', () => {
+      const target = { ...ohBase };
+      const plan = deriveSwitchPlan(ohBase, target, null);
+      expect(plan.action).toBe('current');
+    });
+  });
+
+  describe('kind change', () => {
+    it('returns start-new when switching from OpenHands to ACP', () => {
+      const plan = deriveSwitchPlan(ohBase, acpBase, claudeProvider);
+      expect(plan.action).toBe('start-new');
+      if (plan.action === 'start-new') {
+        expect(plan.reason).toMatch(/agent kind/i);
+      }
+    });
+
+    it('returns start-new when switching from ACP to OpenHands', () => {
+      const plan = deriveSwitchPlan(acpBase, ohBase, claudeProvider);
+      expect(plan.action).toBe('start-new');
+      if (plan.action === 'start-new') {
+        expect(plan.reason).toMatch(/agent kind/i);
+      }
+    });
+  });
+
+  describe('OpenHands → OpenHands', () => {
+    it('switch-live when only llm_profile_ref differs', () => {
+      const target: OpenHandsAgentProfile = { ...ohBase, revision: 1, llm_profile_ref: 'claude-sonnet-4-6' };
+      const plan = deriveSwitchPlan(ohBase, target, null);
+      expect(plan.action).toBe('switch-live');
+      if (plan.action === 'switch-live') {
+        expect(plan.mutableFields).toEqual(['llm_profile_ref']);
+      }
+    });
+
+    it('start-new when agent class also changes', () => {
+      const target: OpenHandsAgentProfile = {
+        ...ohBase,
+        revision: 1,
+        llm_profile_ref: 'claude-sonnet-4-6',
+        agent: 'BrowsingAgent',
+      };
+      const plan = deriveSwitchPlan(ohBase, target, null);
+      expect(plan.action).toBe('start-new');
+      if (plan.action === 'start-new') {
+        expect(plan.reason).toContain('agent');
+      }
+    });
+
+    it('start-new when tool_concurrency_limit changes', () => {
+      const target: OpenHandsAgentProfile = { ...ohBase, revision: 1, tool_concurrency_limit: 4 };
+      const plan = deriveSwitchPlan(ohBase, target, null);
+      expect(plan.action).toBe('start-new');
+    });
+
+    it('start-new when enable_sub_agents changes', () => {
+      const target: OpenHandsAgentProfile = { ...ohBase, revision: 1, enable_sub_agents: true };
+      const plan = deriveSwitchPlan(ohBase, target, null);
+      expect(plan.action).toBe('start-new');
+    });
+  });
+
+  describe('ACP → ACP (same provider)', () => {
+    it('switch-live when only acp_model differs and provider supports it', () => {
+      const target: ACPAgentProfile = { ...acpBase, revision: 1, acp_model: 'claude-opus-4-8' };
+      const plan = deriveSwitchPlan(acpBase, target, claudeProvider);
+      expect(plan.action).toBe('switch-live');
+      if (plan.action === 'switch-live') {
+        expect(plan.mutableFields).toEqual(['acp_model']);
+      }
+    });
+
+    it('start-new when only acp_model differs but provider does NOT support runtime switch', () => {
+      const codexSnapshot: ACPAgentProfile = { ...acpBase, acp_server: 'codex', acp_model: 'gpt-5' };
+      const target: ACPAgentProfile = { ...codexSnapshot, revision: 1, acp_model: 'o4' };
+      const plan = deriveSwitchPlan(codexSnapshot, target, codexProvider);
+      // codex supports_runtime_model_switch check
+      const expected = codexProvider.supports_runtime_model_switch ? 'switch-live' : 'start-new';
+      expect(plan.action).toBe(expected);
+    });
+
+    it('start-new when providerInfo is null and acp_model differs', () => {
+      const target: ACPAgentProfile = { ...acpBase, revision: 1, acp_model: 'claude-opus-4-8' };
+      const plan = deriveSwitchPlan(acpBase, target, null);
+      expect(plan.action).toBe('start-new');
+      if (plan.action === 'start-new') {
+        expect(plan.reason).toMatch(/runtime model switch/i);
+      }
+    });
+
+    it('start-new when acp_session_mode also changes', () => {
+      const target: ACPAgentProfile = {
+        ...acpBase,
+        revision: 1,
+        acp_model: 'claude-opus-4-8',
+        acp_session_mode: 'bypassPermissions',
+      };
+      const plan = deriveSwitchPlan(acpBase, target, claudeProvider);
+      expect(plan.action).toBe('start-new');
+      if (plan.action === 'start-new') {
+        expect(plan.reason).toContain('acp_session_mode');
+      }
+    });
+
+    it('current when ACP profiles identical except id+revision fastpath skipped but content same', () => {
+      const target: ACPAgentProfile = { ...acpBase };
+      const plan = deriveSwitchPlan(acpBase, target, claudeProvider);
+      expect(plan.action).toBe('current');
+    });
+  });
+
+  describe('ACP → ACP (provider change)', () => {
+    it('start-new when acp_server changes', () => {
+      const target: ACPAgentProfile = { ...acpBase, revision: 1, acp_server: 'codex' };
+      const plan = deriveSwitchPlan(acpBase, target, claudeProvider);
+      expect(plan.action).toBe('start-new');
+      if (plan.action === 'start-new') {
+        expect(plan.reason).toMatch(/provider/i);
+      }
+    });
+  });
+});

--- a/src/__tests__/derive-switch-plan.test.ts
+++ b/src/__tests__/derive-switch-plan.test.ts
@@ -97,7 +97,11 @@ describe('deriveSwitchPlan', () => {
 
   describe('OpenHands → OpenHands', () => {
     it('switch-live when only llm_profile_ref differs', () => {
-      const target: OpenHandsAgentProfile = { ...ohBase, revision: 1, llm_profile_ref: 'claude-sonnet-4-6' };
+      const target: OpenHandsAgentProfile = {
+        ...ohBase,
+        revision: 1,
+        llm_profile_ref: 'claude-sonnet-4-6',
+      };
       const plan = deriveSwitchPlan(ohBase, target, null);
       expect(plan.action).toBe('switch-live');
       if (plan.action === 'switch-live') {
@@ -143,7 +147,11 @@ describe('deriveSwitchPlan', () => {
     });
 
     it('start-new when only acp_model differs but provider does NOT support runtime switch', () => {
-      const codexSnapshot: ACPAgentProfile = { ...acpBase, acp_server: 'codex', acp_model: 'gpt-5' };
+      const codexSnapshot: ACPAgentProfile = {
+        ...acpBase,
+        acp_server: 'codex',
+        acp_model: 'gpt-5',
+      };
       const target: ACPAgentProfile = { ...codexSnapshot, revision: 1, acp_model: 'o4' };
       const plan = deriveSwitchPlan(codexSnapshot, target, codexProvider);
       // codex supports_runtime_model_switch check

--- a/src/__tests__/derive-switch-plan.test.ts
+++ b/src/__tests__/derive-switch-plan.test.ts
@@ -182,9 +182,18 @@ describe('deriveSwitchPlan', () => {
       }
     });
 
-    it('current when ACP profiles identical except id+revision fastpath skipped but content same', () => {
-      const target: ACPAgentProfile = { ...acpBase };
+    it('current when ACP content identical but id+revision differ (fast-path skipped)', () => {
+      const target: ACPAgentProfile = { ...acpBase, id: 'profile-9', revision: 5 };
       const plan = deriveSwitchPlan(acpBase, target, claudeProvider);
+      expect(plan.action).toBe('current');
+    });
+
+    it('current when ACP content identical even if provider lacks runtime switch', () => {
+      // Regression: an unchanged profile must be "current" regardless of the
+      // provider's runtime-switch capability. providerInfo=null (custom server)
+      // previously returned a spurious "start-new".
+      const target: ACPAgentProfile = { ...acpBase, id: 'profile-9', revision: 5 };
+      const plan = deriveSwitchPlan(acpBase, target, null);
       expect(plan.action).toBe('current');
     });
   });

--- a/src/client/agent-profiles-client.ts
+++ b/src/client/agent-profiles-client.ts
@@ -1,0 +1,153 @@
+import { HttpClient } from './http-client';
+import type {
+  AgentProfile,
+  AgentProfileDiagnostics,
+  AgentProfileSummary,
+} from '../models/agent-profile';
+import type { ExposeSecretsMode } from '../models/api';
+
+export interface AgentProfilesClientOptions {
+  host: string;
+  apiKey?: string;
+  timeout?: number;
+}
+
+export interface GetAgentProfileOptions {
+  /**
+   * Controls server-side `skills[].mcp_tools` secret exposure via
+   * `X-Expose-Secrets`:
+   * - `"encrypted"`: Fernet-encrypted values (safe for frontend round-trip)
+   * - `"plaintext"`: raw secret values (backend clients only)
+   * - omitted: values are masked/redacted
+   */
+  exposeSecrets?: ExposeSecretsMode;
+}
+
+export interface AgentProfileListResponse {
+  profiles: AgentProfileSummary[];
+  active_agent_profile_id: string | null;
+}
+
+export interface AgentProfileDetailResponse {
+  name: string;
+  profile: Record<string, unknown>;
+}
+
+export interface AgentProfileMutationResponse {
+  name: string;
+  message: string;
+}
+
+export interface ActivateAgentProfileResponse {
+  id: string;
+  message: string;
+  /** Always false — activation is pointer-only (does not write agent_settings). */
+  agent_settings_applied: boolean;
+}
+
+/**
+ * Client for the agent-server `/api/agent-profiles` endpoints.
+ *
+ * Mirrors `agent_profiles_router.py` in the OpenHands agent-server.
+ * Error status codes surfaced via `HttpError.status`:
+ * - 404: profile not found (get/delete/rename/materialize)
+ * - 409: profile limit exceeded (save) or new_name already exists (rename)
+ * - 422: validation error (save) or dangling MCP ref (materialize)
+ */
+export class AgentProfilesClient {
+  public readonly host: string;
+  public readonly apiKey?: string;
+  private readonly client: HttpClient;
+
+  constructor(options: AgentProfilesClientOptions) {
+    this.host = options.host.replace(/\/$/, '');
+    this.apiKey = options.apiKey;
+    this.client = new HttpClient({
+      baseUrl: this.host,
+      apiKey: this.apiKey,
+      timeout: options.timeout ?? 60000,
+    });
+  }
+
+  async listAgentProfiles(): Promise<AgentProfileListResponse> {
+    const response = await this.client.get<AgentProfileListResponse>('/api/agent-profiles');
+    return response.data;
+  }
+
+  async getAgentProfile(
+    name: string,
+    options: GetAgentProfileOptions = {}
+  ): Promise<AgentProfileDetailResponse> {
+    const headers: Record<string, string> = {};
+    if (options.exposeSecrets) {
+      headers['X-Expose-Secrets'] = options.exposeSecrets;
+    }
+    const response = await this.client.get<AgentProfileDetailResponse>(
+      `/api/agent-profiles/${encodeURIComponent(name)}`,
+      { headers }
+    );
+    return response.data;
+  }
+
+  async saveAgentProfile(
+    name: string,
+    profile: Partial<AgentProfile> & { agent_kind?: string }
+  ): Promise<AgentProfileMutationResponse> {
+    const response = await this.client.post<AgentProfileMutationResponse>(
+      `/api/agent-profiles/${encodeURIComponent(name)}`,
+      profile
+    );
+    return response.data;
+  }
+
+  async deleteAgentProfile(name: string): Promise<AgentProfileMutationResponse> {
+    const response = await this.client.delete<AgentProfileMutationResponse>(
+      `/api/agent-profiles/${encodeURIComponent(name)}`
+    );
+    return response.data;
+  }
+
+  async renameAgentProfile(
+    name: string,
+    newName: string
+  ): Promise<AgentProfileMutationResponse> {
+    const response = await this.client.post<AgentProfileMutationResponse>(
+      `/api/agent-profiles/${encodeURIComponent(name)}/rename`,
+      { new_name: newName }
+    );
+    return response.data;
+  }
+
+  /**
+   * Activate a profile by its stable UUID.
+   * Pointer-only — does NOT write `agent_settings`.
+   *
+   * @param profileId  The stable `id` UUID of the profile to activate.
+   */
+  async activateAgentProfile(profileId: string): Promise<ActivateAgentProfileResponse> {
+    const response = await this.client.post<ActivateAgentProfileResponse>(
+      `/api/agent-profiles/${encodeURIComponent(profileId)}/activate`,
+      {}
+    );
+    return response.data;
+  }
+
+  /**
+   * Dry-run resolve a profile's LLM/MCP references.
+   * Returns an {@link AgentProfileDiagnostics} report; never raises on
+   * dangling refs — those appear in the body with `valid: false`.
+   *
+   * @param name  Profile name (path slug, not the UUID).
+   */
+  async materializeAgentProfile(name: string): Promise<AgentProfileDiagnostics> {
+    const response = await this.client.post<AgentProfileDiagnostics>(
+      `/api/agent-profiles/${encodeURIComponent(name)}/materialize`,
+      {}
+    );
+    return response.data;
+  }
+
+  close(): void {
+    this.client.close();
+  }
+}

--- a/src/client/agent-profiles-client.ts
+++ b/src/client/agent-profiles-client.ts
@@ -2,6 +2,7 @@ import { HttpClient } from './http-client';
 import type {
   AgentProfile,
   AgentProfileDiagnostics,
+  AgentProfileSaveInput,
   AgentProfileSummary,
 } from '../models/agent-profile';
 import type { ExposeSecretsMode } from '../models/api';
@@ -30,7 +31,7 @@ export interface AgentProfileListResponse {
 
 export interface AgentProfileDetailResponse {
   name: string;
-  profile: Record<string, unknown>;
+  profile: AgentProfile;
 }
 
 export interface AgentProfileMutationResponse {
@@ -50,9 +51,13 @@ export interface ActivateAgentProfileResponse {
  *
  * Mirrors `agent_profiles_router.py` in the OpenHands agent-server.
  * Error status codes surfaced via `HttpError.status`:
- * - 404: profile not found (get/delete/rename/materialize)
+ * - 404: profile not found (get/rename/materialize)
  * - 409: profile limit exceeded (save) or new_name already exists (rename)
- * - 422: validation error (save) or dangling MCP ref (materialize)
+ * - 422: validation error (save)
+ *
+ * `delete` is idempotent — a missing name resolves 200, not 404. `materialize`
+ * never raises on dangling LLM/MCP refs; they are reported in the response body
+ * (`valid: false`, `dangling_mcp_server_refs`), not as a 4xx.
  */
 export class AgentProfilesClient {
   public readonly host: string;
@@ -91,7 +96,7 @@ export class AgentProfilesClient {
 
   async saveAgentProfile(
     name: string,
-    profile: Partial<AgentProfile> & { agent_kind?: string }
+    profile: AgentProfileSaveInput
   ): Promise<AgentProfileMutationResponse> {
     const response = await this.client.post<AgentProfileMutationResponse>(
       `/api/agent-profiles/${encodeURIComponent(name)}`,

--- a/src/client/agent-profiles-client.ts
+++ b/src/client/agent-profiles-client.ts
@@ -107,10 +107,7 @@ export class AgentProfilesClient {
     return response.data;
   }
 
-  async renameAgentProfile(
-    name: string,
-    newName: string
-  ): Promise<AgentProfileMutationResponse> {
+  async renameAgentProfile(name: string, newName: string): Promise<AgentProfileMutationResponse> {
     const response = await this.client.post<AgentProfileMutationResponse>(
       `/api/agent-profiles/${encodeURIComponent(name)}/rename`,
       { new_name: newName }

--- a/src/client/conversation-client.ts
+++ b/src/client/conversation-client.ts
@@ -25,7 +25,23 @@ export interface ConversationClientOptions {
   timeout?: number;
 }
 
-export type CreateConversationPayload = Record<string, unknown>;
+/**
+ * Payload for creating a new conversation.
+ *
+ * Mutually exclusive sources for the agent:
+ * - `agent_profile_id` — stable UUID; server resolves the profile server-side.
+ * - `agent` / `agent_settings` — direct agent spec (legacy path).
+ *
+ * Additional fields (e.g. `initial_message`, `max_iterations`) are forwarded
+ * as-is. `agent_profile_id` support lands with SDK PR #3784.
+ */
+export interface CreateConversationPayload {
+  /** Stable UUID of an agent profile to resolve server-side. */
+  agent_profile_id?: string;
+  agent?: unknown;
+  agent_settings?: unknown;
+  [key: string]: unknown;
+}
 
 export interface SendConversationEventOptions {
   run?: boolean;

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,3 +1,4 @@
+export { AgentProfilesClient } from './client/agent-profiles-client';
 export { ServerClient } from './client/server-client';
 export { BashClient } from './client/bash-client';
 export { CloudProxyClient } from './client/cloud-proxy-client';
@@ -42,6 +43,14 @@ export type { HooksClientOptions } from './client/hooks-client';
 export type { LLMMetadataClientOptions } from './client/llm-client';
 export type { MCPClientOptions } from './client/mcp-client';
 export type { ProfilesClientOptions, GetProfileOptions } from './client/profiles-client';
+export type {
+  AgentProfilesClientOptions,
+  GetAgentProfileOptions,
+  AgentProfileListResponse,
+  AgentProfileDetailResponse,
+  AgentProfileMutationResponse,
+  ActivateAgentProfileResponse,
+} from './client/agent-profiles-client';
 export type { MetaProfilesClientOptions } from './client/meta-profiles-client';
 export type {
   SettingsClientOptions,

--- a/src/conversation/conversation-manager.ts
+++ b/src/conversation/conversation-manager.ts
@@ -3,6 +3,7 @@
  */
 
 import { HttpClient } from '../client/http-client';
+import { AgentProfilesClient } from '../client/agent-profiles-client';
 import { ApiKeysClient } from '../client/api-keys-client';
 import { CloudProxyClient } from '../client/cloud-proxy-client';
 import { DesktopClient } from '../client/desktop-client';
@@ -85,6 +86,7 @@ export class ConversationManager {
   public readonly server: ServerClient;
   public readonly llm: LLMMetadataClient;
   public readonly profiles: ProfilesClient;
+  public readonly agentProfiles: AgentProfilesClient;
   public readonly metaProfiles: MetaProfilesClient;
   public readonly settings: SettingsClient;
   public readonly skills: SkillsClient;
@@ -120,6 +122,7 @@ export class ConversationManager {
     this.server = new ServerClient(clientOptions);
     this.llm = new LLMMetadataClient(clientOptions);
     this.profiles = new ProfilesClient(clientOptions);
+    this.agentProfiles = new AgentProfilesClient(clientOptions);
     this.metaProfiles = new MetaProfilesClient(clientOptions);
     this.settings = new SettingsClient(clientOptions);
     this.skills = new SkillsClient(clientOptions);

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,32 @@ export type {
 export { ACP_PROVIDERS, ACP_SETTINGS_KEYS, getAcpProvider } from './models/acp';
 export type { ACPModelOption, ACPProviderInfo, ACPProviderKey } from './models/acp';
 
+// Agent profile types (mirrors openhands-sdk agent_profile.py + resolver.py)
+export type {
+  ProfileVerificationSettings,
+  OpenHandsAgentProfile,
+  ACPAgentProfile,
+  AgentProfile,
+  AgentProfileSummary,
+  AgentProfileDiagnostics,
+  LaunchedProfile,
+} from './models/agent-profile';
+
+// Agent profiles client
+export { AgentProfilesClient } from './client/agent-profiles-client';
+export type {
+  AgentProfilesClientOptions,
+  GetAgentProfileOptions,
+  AgentProfileListResponse,
+  AgentProfileDetailResponse,
+  AgentProfileMutationResponse,
+  ActivateAgentProfileResponse,
+} from './client/agent-profiles-client';
+
+// deriveSwitchPlan — pure profile-switch decision helper
+export { deriveSwitchPlan } from './profiles/derive-switch-plan';
+export type { SwitchPlan } from './profiles/derive-switch-plan';
+
 // Conversation models
 export type {
   ConversationInfo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,10 +221,13 @@ export type { ACPModelOption, ACPProviderInfo, ACPProviderKey } from './models/a
 
 // Agent profile types (mirrors openhands-sdk agent_profile.py + resolver.py)
 export type {
+  AgentKind,
+  ACPServerKind,
   ProfileVerificationSettings,
   OpenHandsAgentProfile,
   ACPAgentProfile,
   AgentProfile,
+  AgentProfileSaveInput,
   AgentProfileSummary,
   AgentProfileDiagnostics,
   LaunchedProfile,

--- a/src/models/agent-profile.ts
+++ b/src/models/agent-profile.ts
@@ -7,7 +7,15 @@
  * credentials, mirroring the Python design. See epic #3713.
  */
 
+import type { ACPProviderKey } from './acp';
+
 // ── Shared supporting types ──────────────────────────────────────────────────
+
+/** Discriminator across the {@link AgentProfile} union. */
+export type AgentKind = 'openhands' | 'acp';
+
+/** ACP backend selector: a built-in provider key or the `'custom'` sentinel. */
+export type ACPServerKind = ACPProviderKey | 'custom';
 
 /** Secret-free critic/refinement policy stored inside an OpenHands profile. */
 export interface ProfileVerificationSettings {
@@ -54,8 +62,8 @@ export interface OpenHandsAgentProfile extends AgentProfileBase {
 /** `agent_kind="acp"` variant — names an ACP backend; stores no credential. */
 export interface ACPAgentProfile extends AgentProfileBase {
   agent_kind: 'acp';
-  /** ACP provider key: "claude-code" | "codex" | "gemini-cli" | "custom". */
-  acp_server: string;
+  /** ACP provider key, or `'custom'` for a user-supplied command. */
+  acp_server: ACPServerKind;
   acp_model: string | null;
   acp_session_mode: string | null;
   acp_prompt_timeout: number;
@@ -71,13 +79,27 @@ export interface ACPAgentProfile extends AgentProfileBase {
  */
 export type AgentProfile = OpenHandsAgentProfile | ACPAgentProfile;
 
+/**
+ * Request body for `POST /api/agent-profiles/{name}` (create or overwrite).
+ *
+ * Discriminated on `agent_kind`, so a payload cannot mix fields from the other
+ * variant (the server model is `extra=forbid`). Non-discriminant fields are
+ * optional: server-managed identity (`id`/`revision`/`schema_version`) is
+ * minted on create and preserved on overwrite. A field left unset takes the
+ * server-side default where one exists — except `llm_profile_ref`, which is
+ * required for the `openhands` variant (omitting it yields a 422).
+ */
+export type AgentProfileSaveInput =
+  | ({ agent_kind: 'openhands' } & Partial<Omit<OpenHandsAgentProfile, 'agent_kind'>>)
+  | ({ agent_kind: 'acp' } & Partial<Omit<ACPAgentProfile, 'agent_kind'>>);
+
 // ── Summary projection (list endpoint) ──────────────────────────────────────
 
 /** Lightweight summary returned by the list endpoint. */
 export interface AgentProfileSummary {
   id: string | null;
   name: string;
-  agent_kind: string;
+  agent_kind: AgentKind;
   revision: number | null;
   llm_profile_ref: string | null;
   mcp_server_refs: string[] | null;
@@ -92,7 +114,7 @@ export interface AgentProfileSummary {
  * Dangling references are reported here (valid=false) rather than as HTTP errors.
  */
 export interface AgentProfileDiagnostics {
-  agent_kind: string;
+  agent_kind: AgentKind;
   valid: boolean;
   errors: string[];
 

--- a/src/models/agent-profile.ts
+++ b/src/models/agent-profile.ts
@@ -1,0 +1,132 @@
+/**
+ * AgentProfile — TypeScript mirror of the Python SDK's
+ * `openhands.sdk.profiles.agent_profile` module.
+ *
+ * The AgentProfile union is discriminated on `agent_kind` and carries
+ * *references* (llm_profile_ref / mcp_server_refs) rather than resolved
+ * credentials, mirroring the Python design. See epic #3713.
+ */
+
+// ── Shared supporting types ──────────────────────────────────────────────────
+
+/** Secret-free critic/refinement policy stored inside an OpenHands profile. */
+export interface ProfileVerificationSettings {
+  critic_enabled: boolean;
+  critic_mode: string;
+  enable_iterative_refinement: boolean;
+  critic_threshold: number;
+  max_refinement_iterations: number;
+  critic_server_url: string | null;
+  critic_model_name: string | null;
+}
+
+// ── Profile variants ─────────────────────────────────────────────────────────
+
+interface AgentProfileBase {
+  schema_version?: number;
+  /** Stable UUID handle — never changes on rename. */
+  id: string;
+  /** Human-facing, renameable key. */
+  name: string;
+  /** Monotonic revision counter, bumped on each saved edit. */
+  revision: number;
+  /**
+   * Which of the user's globally configured MCP servers to expose.
+   * `null` = all; `[]` = none; a non-null list = filter to the named keys.
+   */
+  mcp_server_refs: string[] | null;
+}
+
+/** `agent_kind="openhands"` variant — references an LLM profile by name. */
+export interface OpenHandsAgentProfile extends AgentProfileBase {
+  agent_kind: 'openhands';
+  /** Name of the LLM profile to resolve. */
+  llm_profile_ref: string;
+  agent: string;
+  skills: unknown[];
+  system_message_suffix: string | null;
+  condenser: unknown;
+  verification: ProfileVerificationSettings;
+  enable_sub_agents: boolean;
+  tool_concurrency_limit: number;
+}
+
+/** `agent_kind="acp"` variant — names an ACP backend; stores no credential. */
+export interface ACPAgentProfile extends AgentProfileBase {
+  agent_kind: 'acp';
+  /** ACP provider key: "claude-code" | "codex" | "gemini-cli" | "custom". */
+  acp_server: string;
+  acp_model: string | null;
+  acp_session_mode: string | null;
+  acp_prompt_timeout: number;
+  acp_command: string | null;
+  acp_args: string[] | null;
+}
+
+/**
+ * Discriminated union on `agent_kind`. Use the `agent_kind` field to narrow:
+ * ```ts
+ * if (profile.agent_kind === 'openhands') { ... }
+ * ```
+ */
+export type AgentProfile = OpenHandsAgentProfile | ACPAgentProfile;
+
+// ── Summary projection (list endpoint) ──────────────────────────────────────
+
+/** Lightweight summary returned by the list endpoint. */
+export interface AgentProfileSummary {
+  id: string | null;
+  name: string;
+  agent_kind: string;
+  revision: number | null;
+  llm_profile_ref: string | null;
+  mcp_server_refs: string[] | null;
+}
+
+// ── Materialize diagnostics ──────────────────────────────────────────────────
+
+/**
+ * Dry-run resolve report returned by `POST /api/agent-profiles/{name}/materialize`.
+ * Mirrors `openhands.sdk.profiles.resolver.AgentProfileDiagnostics` field-for-field.
+ *
+ * Dangling references are reported here (valid=false) rather than as HTTP errors.
+ */
+export interface AgentProfileDiagnostics {
+  agent_kind: string;
+  valid: boolean;
+  errors: string[];
+
+  // OpenHands LLM reference.
+  llm_profile_ref: string | null;
+  llm_profile_resolved: boolean;
+  llm_api_key_set: boolean;
+
+  // MCP composition (both variants).
+  mcp_server_refs: string[] | null;
+  resolved_mcp_servers: string[];
+  dangling_mcp_server_refs: string[];
+
+  // ACP provider credential channels (ACP variant only).
+  acp_api_key_secret_name: string | null;
+  acp_base_url_secret_name: string | null;
+  acp_file_secret_names: string[];
+
+  // Redacted resolved settings, present iff valid.
+  resolved_settings: Record<string, unknown> | null;
+}
+
+// ── Provenance (Part B — lands with PR #3784) ────────────────────────────────
+
+/**
+ * Provenance snapshot recorded when a profile launches a conversation.
+ * Mirrors `openhands.sdk.profiles.agent_profile.LaunchedProfile`.
+ *
+ * Stored on the conversation so clients can identify which profile is current
+ * without fragile settings-comparison. See epic #3713.
+ */
+export interface LaunchedProfile {
+  /** Stable id of the profile that launched the conversation. */
+  profile_id: string;
+  /** Revision of the profile at launch time. */
+  revision: number;
+}

--- a/src/models/conversation.ts
+++ b/src/models/conversation.ts
@@ -14,6 +14,7 @@ import {
   Message,
 } from '../types/base';
 import type { HookConfig } from '../hooks';
+import type { LaunchedProfile } from './agent-profile';
 
 export enum ConversationSortOrder {
   CREATED_AT = 'CREATED_AT',
@@ -51,6 +52,13 @@ export interface ConversationInfo {
   created_at?: string;
   updated_at?: string;
   tags?: Record<string, string>;
+  /**
+   * Provenance of the agent profile that launched this conversation.
+   * Present when the conversation was started via `agent_profile_id`; absent
+   * for conversations started directly with `agent` or `agent_settings`.
+   * Lands with SDK PR #3784.
+   */
+  launched_profile?: LaunchedProfile | null;
   /**
    * @deprecated Use execution_status instead. This field is kept for backward compatibility.
    */

--- a/src/profiles/derive-switch-plan.ts
+++ b/src/profiles/derive-switch-plan.ts
@@ -19,6 +19,27 @@ export type SwitchPlan =
 // Fields excluded from content comparison (identity / provenance fields).
 const IDENTITY_FIELDS = new Set(['id', 'name', 'revision', 'schema_version', 'agent_kind']);
 
+/**
+ * Deterministic serialization with object keys sorted recursively. Two values
+ * with identical content but different key *insertion order* serialize equal
+ * (array order stays significant). A snapshot round-tripped through storage
+ * must not look "changed" merely because its keys were re-ordered.
+ */
+function stableStringify(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const entries = Object.keys(obj)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(obj[key])}`);
+  return `{${entries.join(',')}}`;
+}
+
 function changedNonMutableFields(
   a: Record<string, unknown>,
   b: Record<string, unknown>,
@@ -28,7 +49,7 @@ function changedNonMutableFields(
   const changed: string[] = [];
   for (const key of allKeys) {
     if (IDENTITY_FIELDS.has(key) || mutable.has(key)) continue;
-    if (JSON.stringify(a[key]) !== JSON.stringify(b[key])) {
+    if (stableStringify(a[key]) !== stableStringify(b[key])) {
       changed.push(key);
     }
   }
@@ -106,21 +127,27 @@ export function deriveSwitchPlan(
       return { action: 'start-new', reason: 'ACP provider changed' };
     }
 
-    // ACP → ACP (same provider): live only if just acp_model differs and
-    // the provider supports runtime model switching.
+    // ACP → ACP (same provider): acp_model is the only field that can switch
+    // live. Any other content change forces a new conversation.
     const nonMutable = changedNonMutableFields(snapshotRaw, targetRaw, new Set(['acp_model']));
     if (nonMutable.length > 0) {
       return { action: 'start-new', reason: `fields changed: ${nonMutable.join(', ')}` };
     }
+
+    // Identical model (and nothing else changed) → already current, regardless
+    // of provider capability. Check this before the runtime-switch gate so an
+    // unchanged profile is never mistaken for a switch.
+    const modelDiffers = snapshotAcp.acp_model !== targetAcp.acp_model;
+    if (!modelDiffers) {
+      return { action: 'current' };
+    }
+
+    // Model differs → live switch only if the provider supports it.
     if (!providerInfo?.supports_runtime_model_switch) {
       return {
         action: 'start-new',
         reason: 'provider does not support runtime model switch',
       };
-    }
-    const modelDiffers = snapshotAcp.acp_model !== targetAcp.acp_model;
-    if (!modelDiffers) {
-      return { action: 'current' };
     }
     return { action: 'switch-live', mutableFields: ['acp_model'] };
   }

--- a/src/profiles/derive-switch-plan.ts
+++ b/src/profiles/derive-switch-plan.ts
@@ -81,7 +81,11 @@ export function deriveSwitchPlan(
 
   if (snapshot.agent_kind === 'openhands') {
     // OpenHands → OpenHands: live only if just llm_profile_ref differs.
-    const nonMutable = changedNonMutableFields(snapshotRaw, targetRaw, new Set(['llm_profile_ref']));
+    const nonMutable = changedNonMutableFields(
+      snapshotRaw,
+      targetRaw,
+      new Set(['llm_profile_ref'])
+    );
     if (nonMutable.length === 0) {
       const llmDiffers =
         snapshot.llm_profile_ref !== (targetProfile as OpenHandsAgentProfile).llm_profile_ref;
@@ -123,5 +127,8 @@ export function deriveSwitchPlan(
 
   // Unreachable with a valid AgentProfile union, but guards against future variants.
   const exhaustiveCheck: never = snapshot;
-  return { action: 'disabled', reason: `unknown agent_kind: ${(exhaustiveCheck as { agent_kind: string }).agent_kind}` };
+  return {
+    action: 'disabled',
+    reason: `unknown agent_kind: ${(exhaustiveCheck as { agent_kind: string }).agent_kind}`,
+  };
 }

--- a/src/profiles/derive-switch-plan.ts
+++ b/src/profiles/derive-switch-plan.ts
@@ -1,0 +1,127 @@
+/**
+ * deriveSwitchPlan — pure helper that decides whether a profile switch can
+ * happen live (in-conversation), requires a new conversation, or is already
+ * current.
+ *
+ * Lives in its own module so the canvas can import it without pulling in HTTP
+ * client code, and so it can be unit-tested without any I/O.
+ */
+
+import type { ACPProviderInfo } from '../models/acp';
+import type { ACPAgentProfile, OpenHandsAgentProfile } from '../models/agent-profile';
+
+export type SwitchPlan =
+  | { action: 'current' }
+  | { action: 'switch-live'; mutableFields: string[] }
+  | { action: 'start-new'; reason: string }
+  | { action: 'disabled'; reason: string };
+
+// Fields excluded from content comparison (identity / provenance fields).
+const IDENTITY_FIELDS = new Set(['id', 'name', 'revision', 'schema_version', 'agent_kind']);
+
+function changedNonMutableFields(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+  mutable: Set<string>
+): string[] {
+  const allKeys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  const changed: string[] = [];
+  for (const key of allKeys) {
+    if (IDENTITY_FIELDS.has(key) || mutable.has(key)) continue;
+    if (JSON.stringify(a[key]) !== JSON.stringify(b[key])) {
+      changed.push(key);
+    }
+  }
+  return changed;
+}
+
+/**
+ * Compute a {@link SwitchPlan} for transitioning a running conversation from
+ * the currently-launched profile content (`snapshot`) to `targetProfile`.
+ *
+ * @param snapshot      Full content of the profile that launched the current
+ *                      conversation, or `null`/`undefined` when no profile was
+ *                      used at conversation start.
+ * @param targetProfile The profile the user wants to apply.
+ * @param providerInfo  ACP provider info for the *current* agent (from
+ *                      {@link getAcpProvider}), or `null` for OpenHands or
+ *                      custom ACP servers. Used to check
+ *                      `supports_runtime_model_switch`.
+ *
+ * Decision rules (mirrors epic #3713):
+ * - **current**: `snapshot` content is identical to `targetProfile` content.
+ * - **switch-live**: can transition without restarting the conversation:
+ *   - OpenHands → OpenHands: only `llm_profile_ref` differs.
+ *   - ACP → ACP: same `acp_server`, only `acp_model` differs, and the
+ *     provider declares `supports_runtime_model_switch`.
+ * - **start-new**: possible but requires a fresh conversation.
+ * - **disabled**: no path forward (e.g. unknown agent kind).
+ */
+export function deriveSwitchPlan(
+  snapshot: OpenHandsAgentProfile | ACPAgentProfile | null | undefined,
+  targetProfile: OpenHandsAgentProfile | ACPAgentProfile,
+  providerInfo: ACPProviderInfo | null
+): SwitchPlan {
+  if (!snapshot) {
+    return { action: 'start-new', reason: 'no launched profile' };
+  }
+
+  // Fast-path: exact same profile version already running.
+  if (snapshot.id === targetProfile.id && snapshot.revision === targetProfile.revision) {
+    return { action: 'current' };
+  }
+
+  // Kind change: never a live switch.
+  if (snapshot.agent_kind !== targetProfile.agent_kind) {
+    return { action: 'start-new', reason: 'agent kind changed' };
+  }
+
+  const snapshotRaw = snapshot as unknown as Record<string, unknown>;
+  const targetRaw = targetProfile as unknown as Record<string, unknown>;
+
+  if (snapshot.agent_kind === 'openhands') {
+    // OpenHands → OpenHands: live only if just llm_profile_ref differs.
+    const nonMutable = changedNonMutableFields(snapshotRaw, targetRaw, new Set(['llm_profile_ref']));
+    if (nonMutable.length === 0) {
+      const llmDiffers =
+        snapshot.llm_profile_ref !== (targetProfile as OpenHandsAgentProfile).llm_profile_ref;
+      if (!llmDiffers) {
+        return { action: 'current' };
+      }
+      return { action: 'switch-live', mutableFields: ['llm_profile_ref'] };
+    }
+    return { action: 'start-new', reason: `fields changed: ${nonMutable.join(', ')}` };
+  }
+
+  if (snapshot.agent_kind === 'acp') {
+    const snapshotAcp = snapshot as ACPAgentProfile;
+    const targetAcp = targetProfile as ACPAgentProfile;
+
+    // Different ACP provider → must restart.
+    if (snapshotAcp.acp_server !== targetAcp.acp_server) {
+      return { action: 'start-new', reason: 'ACP provider changed' };
+    }
+
+    // ACP → ACP (same provider): live only if just acp_model differs and
+    // the provider supports runtime model switching.
+    const nonMutable = changedNonMutableFields(snapshotRaw, targetRaw, new Set(['acp_model']));
+    if (nonMutable.length > 0) {
+      return { action: 'start-new', reason: `fields changed: ${nonMutable.join(', ')}` };
+    }
+    if (!providerInfo?.supports_runtime_model_switch) {
+      return {
+        action: 'start-new',
+        reason: 'provider does not support runtime model switch',
+      };
+    }
+    const modelDiffers = snapshotAcp.acp_model !== targetAcp.acp_model;
+    if (!modelDiffers) {
+      return { action: 'current' };
+    }
+    return { action: 'switch-live', mutableFields: ['acp_model'] };
+  }
+
+  // Unreachable with a valid AgentProfile union, but guards against future variants.
+  const exhaustiveCheck: never = snapshot;
+  return { action: 'disabled', reason: `unknown agent_kind: ${(exhaustiveCheck as { agent_kind: string }).agent_kind}` };
+}


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

Implements the TypeScript-client portion of the AgentProfile epic (#3713 in OpenHands/software-agent-sdk). The SDK side (PRs #3757, #3775, #3780, #3781, #3783) is fully merged; this PR mirrors those types and routes into the ts-client.

## Summary

- **`src/models/agent-profile.ts`** — `OpenHandsAgentProfile | ACPAgentProfile` discriminated union on `agent_kind`, plus `AgentProfileSummary`, `AgentProfileDiagnostics` (materialize response), and `LaunchedProfile` provenance type (lands at runtime with SDK PR #3784).
- **`src/client/agent-profiles-client.ts`** — `AgentProfilesClient` covering all `/api/agent-profiles` endpoints: list / get (with `X-Expose-Secrets`) / save / delete / rename / activate (pointer-only) / materialize. FK error statuses (409, 422, 404) surface via `HttpError.status`.
- **`src/profiles/derive-switch-plan.ts`** — pure `deriveSwitchPlan(snapshot, targetProfile, providerInfo)` deciding `current | switch-live | start-new | disabled` per epic rules: OpenHands→OpenHands live if only `llm_profile_ref` differs; ACP→ACP live if same provider + only `acp_model` differs + `supports_runtime_model_switch`.
- **Wiring** — `ConversationManager.agentProfiles`, exports from `src/clients.ts` + `src/index.ts`, typed `agent_profile_id` on `CreateConversationPayload`, `launched_profile` on `ConversationInfo`.
- **24 new tests** (7 client HTTP tests + 17 `deriveSwitchPlan` coverage across all providers and OpenHands).

## Issue Number

OpenHands/software-agent-sdk#3722

## How to Test

```
$ ./node_modules/.bin/tsc --noEmit
(clean — no output)

$ npm test
Test Suites: 14 passed, 14 total
Tests:       253 passed, 253 total (229 pre-existing + 24 new)
Snapshots:   0 total
Time:        4.054 s

$ npm run lint
✖ 17 problems (0 errors, 17 warnings)
(all warnings pre-existing — none from this PR)

$ npm run build
(clean)
```

**Part B note:** `agent_profile_id` on `CreateConversationPayload` and `launched_profile` on `ConversationInfo` are typed and documented; they wire up at runtime once SDK PR #3784 merges.

## Type

## Notes

`deriveSwitchPlan` is intentionally pure — no HTTP calls, no imports from the client module. Canvas imports it directly to render the switch-plan UI.