### PR TITLE
feat(FileClient): forward include_hidden to /api/file/home and /search_subdirs

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -1362,6 +1362,66 @@ describe('Auxiliary API clients', () => {
     );
   });
 
+  it('FileClient forwards includeHidden to the home and search_subdirs endpoints', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ home: '/workspace' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ items: [], next_page_id: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+
+    const client = new FileClient({ host: 'http://example.com' });
+    await expect(client.getHome({ includeHidden: true })).resolves.toEqual({
+      home: '/workspace',
+    });
+    await client.searchSubdirectories('/workspace', { includeHidden: true });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://example.com/api/file/home?include_hidden=true',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://example.com/api/file/search_subdirs?path=%2Fworkspace&include_hidden=true',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('FileClient omits include_hidden when includeHidden is not set', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ home: '/workspace' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ items: [], next_page_id: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+
+    const client = new FileClient({ host: 'http://example.com' });
+    await client.getHome();
+    await client.searchSubdirectories('/workspace');
+
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toBe('http://example.com/api/file/home');
+    expect((global.fetch as jest.Mock).mock.calls[1][0]).toBe(
+      'http://example.com/api/file/search_subdirs?path=%2Fworkspace'
+    );
+  });
+
   it('ConversationClient wraps agent-canvas conversation endpoints', async () => {
     global.fetch = jest.fn().mockImplementation(() =>
       Promise.resolve(

--- a/src/client/file-client.ts
+++ b/src/client/file-client.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from './http-client';
 import type {
+  FileHomeOptions,
   FileHomeResponse,
   FileSearchSubdirsOptions,
   FileSubdirectoryPage,
@@ -38,13 +39,18 @@ export class FileClient {
         path,
         page_id: options.pageId,
         limit: options.limit,
+        include_hidden: options.includeHidden || undefined,
       },
     });
     return response.data;
   }
 
-  async getHome(): Promise<FileHomeResponse> {
-    const response = await this.client.get<FileHomeResponse>('/api/file/home');
+  async getHome(options: FileHomeOptions = {}): Promise<FileHomeResponse> {
+    const response = await this.client.get<FileHomeResponse>('/api/file/home', {
+      params: {
+        include_hidden: options.includeHidden || undefined,
+      },
+    });
     return response.data;
   }
 

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -289,13 +289,27 @@ export interface FileSubdirectoryPage {
   next_page_id: string | null;
 }
 
+export interface FileBrowserEntry {
+  label: string;
+  path: string;
+}
+
 export interface FileHomeResponse {
   home: string;
+  favorites?: FileBrowserEntry[];
+  locations?: FileBrowserEntry[];
+}
+
+export interface FileHomeOptions {
+  /** Include hidden top-level directories in the response's `favorites`. */
+  includeHidden?: boolean;
 }
 
 export interface FileSearchSubdirsOptions {
   pageId?: string | null;
   limit?: number;
+  /** Include hidden subdirectories (names starting with '.'). */
+  includeHidden?: boolean;
 }
 
 export interface CloudProxyRequest {


### PR DESCRIPTION
## Why

agent-canvas wants a "Show hidden folders" toggle in its folder browser, but the agent-server's `/api/file/home` and `/api/file/search_subdirs` endpoints filter out hidden (dot-) entries by default. The server is gaining an `include_hidden` query param (OpenHands/software-agent-sdk#3740), but the typed `FileClient` here has no way to forward it — so the frontend would be forced to construct the low-level `HttpClient` directly, which agent-canvas's API-access guard explicitly bans.

## Summary

- Added an optional `includeHidden` flag to `FileHomeOptions` and `FileSearchSubdirsOptions`.
- `FileClient.getHome({ includeHidden })` and `FileClient.searchSubdirectories(path, { includeHidden })` now forward `include_hidden=true` when set.
- When unset, the param is omitted entirely, so requests are byte-identical to before (backward compatible).
- Typed the existing `favorites` / `locations` fields on `FileHomeResponse` as `FileBrowserEntry[]` (`{ label, path }`), matching the agent-server's `HomeResponse` model.

## Type

- [x] Feature

## Backward compatibility

Purely additive: optional params/options only. Older agent-servers ignore the unknown `include_hidden` query param, so consumers on a newer client + older server keep working (the toggle is just a no-op).

## How to Test

`npm run build && npm test -- --testPathPatterns=api-clients` — adds two tests:

- `FileClient forwards includeHidden to the home and search_subdirs endpoints` — asserts `?include_hidden=true` is appended to both URLs when set.
- `FileClient omits include_hidden when includeHidden is not set` — asserts the param is absent (URL unchanged) when not set.

All 55 api-clients tests pass; build + lint clean.

## Linked

- Depends on server-side support: OpenHands/software-agent-sdk#3740 (`include_hidden` on `/api/file/home` + `/api/file/search_subdirs`).
- Consumed by: agent-canvas "Show hidden folders" toggle (draft PR).

_This PR was created by an AI agent (OpenHands) on behalf of the user._
