### PR TITLE
feat(client): add /goal start, stop, and resume conversation endpoints

### DIFF
--- a/.github/workflows/endpoint-audit.yml
+++ b/.github/workflows/endpoint-audit.yml
@@ -3,6 +3,10 @@ name: Endpoint Audit
 on:
   push:
     branches: [ '**' ]
+  # Required for the "Comment audit report on PR" step: it is gated on
+  # github.event_name == 'pull_request' and relies on the PR context
+  # (context.issue.number), neither of which exists on a push event.
+  pull_request:
 
 # Needed so the audit can post its report as a comment on the PR.
 permissions:

--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -1093,6 +1093,98 @@ describe('Auxiliary API clients', () => {
     );
   });
 
+  it('RemoteConversation.startGoal includes max_iterations only when provided and surfaces HttpError 409', async () => {
+    const agent = new Agent({ llm: { model: 'gpt-4o', api_key: 'k' } });
+    const workspace = new RemoteWorkspace({ host: 'http://example.com', workingDir: '/tmp' });
+    const conversation = new RemoteConversation(agent, workspace, {
+      conversationId: 'conv-123',
+    });
+
+    // Omitted maxIterations must not appear on the wire (server default applies).
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+    await conversation.startGoal('Fix the failing test');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conv-123/goal',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ objective: 'Fix the failing test' }),
+      })
+    );
+
+    // A 409 from the server (run/goal already active) must propagate as HttpError,
+    // and maxIterations must be forwarded when supplied.
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'Conversation run or goal loop already running.' }), {
+        status: 409,
+        statusText: 'Conflict',
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+    const error = await conversation.startGoal('Fix the failing test', 5).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(409);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conv-123/goal',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ objective: 'Fix the failing test', max_iterations: 5 }),
+      })
+    );
+  });
+
+  it('RemoteConversation.resumeGoal POSTs to goal/resume and surfaces HttpError 400 when nothing is resumable', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'no_resumable_goal' }), {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const agent = new Agent({ llm: { model: 'gpt-4o', api_key: 'k' } });
+    const workspace = new RemoteWorkspace({ host: 'http://example.com', workingDir: '/tmp' });
+    const conversation = new RemoteConversation(agent, workspace, {
+      conversationId: 'conv-123',
+    });
+
+    const error = await conversation.resumeGoal().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(400);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conv-123/goal/resume',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({}) })
+    );
+  });
+
+  it('RemoteConversation.stopGoal POSTs to goal/stop and surfaces HttpError 404 for a missing conversation', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'Item not found' }), {
+        status: 404,
+        statusText: 'Not Found',
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const agent = new Agent({ llm: { model: 'gpt-4o', api_key: 'k' } });
+    const workspace = new RemoteWorkspace({ host: 'http://example.com', workingDir: '/tmp' });
+    const conversation = new RemoteConversation(agent, workspace, {
+      conversationId: 'conv-123',
+    });
+
+    const error = await conversation.stopGoal().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(404);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conv-123/goal/stop',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({}) })
+    );
+  });
+
   it('RemoteConversation.setConfirmationPolicy wraps the SDK v1.23.0 request body', async () => {
     global.fetch = jest.fn().mockResolvedValue(
       new Response(JSON.stringify({ success: true }), {
@@ -1639,6 +1731,106 @@ describe('Auxiliary API clients', () => {
       'http://example.com/api/conversations/c1/fork?include_skills=true',
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ title: 'Fork' }) })
     );
+  });
+
+  describe('ConversationClient goal endpoints (error paths)', () => {
+    function mockErrorResponse(status: number, statusText: string, detail: string): void {
+      global.fetch = jest.fn(
+        async () =>
+          new Response(JSON.stringify({ detail }), {
+            status,
+            statusText,
+            headers: { 'content-type': 'application/json' },
+          })
+      ) as typeof fetch;
+    }
+
+    it('startGoal posts the objective and rejects with HttpError 409 when a run is already active', async () => {
+      mockErrorResponse(409, 'Conflict', 'Conversation run or goal loop already running.');
+      const client = new ConversationClient({ host: 'http://example.com' });
+
+      const error = await client
+        .startGoal('c1', { objective: 'Audit the repo', max_iterations: 3 })
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(HttpError);
+      expect((error as HttpError).status).toBe(409);
+      // The failure must still have targeted the right route, method, and body
+      // so a 409 is attributable to server state, not a client contract bug.
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com/api/conversations/c1/goal',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ objective: 'Audit the repo', max_iterations: 3 }),
+        })
+      );
+    });
+
+    it('startGoal rejects with HttpError 400 when the objective is invalid', async () => {
+      mockErrorResponse(400, 'Bad Request', 'Goal objective must not be empty.');
+      const client = new ConversationClient({ host: 'http://example.com' });
+
+      const error = await client.startGoal('c1', { objective: '' }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(HttpError);
+      expect((error as HttpError).status).toBe(400);
+      // max_iterations is omitted from the wire body when not supplied so the
+      // server applies its own default.
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com/api/conversations/c1/goal',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({ objective: '' }) })
+      );
+    });
+
+    it('startGoal rejects with HttpError 404 for an unknown conversation', async () => {
+      mockErrorResponse(404, 'Not Found', 'Item not found');
+      const client = new ConversationClient({ host: 'http://example.com' });
+
+      const error = await client
+        .startGoal('does-not-exist', { objective: 'Audit the repo' })
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(HttpError);
+      expect((error as HttpError).status).toBe(404);
+    });
+
+    it('resumeGoal posts an empty body and rejects with HttpError 400 when there is no resumable goal', async () => {
+      mockErrorResponse(400, 'Bad Request', 'no_resumable_goal');
+      const client = new ConversationClient({ host: 'http://example.com' });
+
+      const error = await client.resumeGoal('c1').catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(HttpError);
+      expect((error as HttpError).status).toBe(400);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com/api/conversations/c1/goal/resume',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({}) })
+      );
+    });
+
+    it('resumeGoal rejects with HttpError 409 when a run or goal loop is already active', async () => {
+      mockErrorResponse(409, 'Conflict', 'Conversation run or goal loop already running.');
+      const client = new ConversationClient({ host: 'http://example.com' });
+
+      const error = await client.resumeGoal('c1').catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(HttpError);
+      expect((error as HttpError).status).toBe(409);
+    });
+
+    it('stopGoal posts an empty body and rejects with HttpError 404 for an unknown conversation', async () => {
+      mockErrorResponse(404, 'Not Found', 'Item not found');
+      const client = new ConversationClient({ host: 'http://example.com' });
+
+      const error = await client.stopGoal('does-not-exist').catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(HttpError);
+      expect((error as HttpError).status).toBe(404);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://example.com/api/conversations/does-not-exist/goal/stop',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify({}) })
+      );
+    });
   });
 
   it('Hooks MCP and CloudProxy clients wrap SDK v1.23.0 endpoints', async () => {

--- a/src/__tests__/integration/deterministic-api.integration.test.ts
+++ b/src/__tests__/integration/deterministic-api.integration.test.ts
@@ -1,4 +1,5 @@
 import { Agent, ConversationManager, HttpError, Workspace } from '../../index';
+import { ConversationClient } from '../../clients';
 import { getServerTestConfig } from './test-config';
 import {
   deleteWorkspaceFile,
@@ -310,6 +311,82 @@ describe('Deterministic API Integration Tests', () => {
         expect(status).toBe(400);
       } finally {
         await manager.deleteConversation(conversation.id).catch(() => undefined);
+      }
+    },
+    config.testTimeout
+  );
+
+  it(
+    'exercises the /goal, /goal/resume, and /goal/stop routes without an LLM',
+    async () => {
+      // Contract guards for the goal endpoints (software-agent-sdk #3770,
+      // released in v1.29.0 — the pinned image). These deliberately stay off
+      // the happy path so they need neither a real LLM nor a background loop:
+      //   - start with an empty objective is rejected by GoalController -> 400
+      //   - resume with nothing to continue -> 400 ("no_resumable_goal")
+      //   - stop with no active loop is a no-op Success -> 200
+      // A 400/200 (not a 404) proves each route exists on the image AND that
+      // the client targets the right path/method/body — client<->server
+      // contract drift the mocked unit tests cannot catch.
+      const conversation = await manager.createConversation(createDummyAgent(), {
+        workingDir: config.agentWorkspaceDir,
+      });
+      try {
+        let startStatus: number | undefined;
+        try {
+          await conversation.startGoal('');
+        } catch (error) {
+          expect(error).toBeInstanceOf(HttpError);
+          startStatus = (error as HttpError).status;
+        }
+        expect(startStatus).toBe(400);
+
+        let resumeStatus: number | undefined;
+        try {
+          await conversation.resumeGoal();
+        } catch (error) {
+          expect(error).toBeInstanceOf(HttpError);
+          resumeStatus = (error as HttpError).status;
+        }
+        expect(resumeStatus).toBe(400);
+
+        // Stopping when no goal loop is running is a no-op Success, not an error.
+        await expect(conversation.stopGoal()).resolves.toBeUndefined();
+      } finally {
+        await manager.deleteConversation(conversation.id).catch(() => undefined);
+      }
+    },
+    config.testTimeout
+  );
+
+  it(
+    'returns 404 from the goal endpoints for an unknown conversation',
+    async () => {
+      // A well-formed but non-existent conversation UUID parses as the path
+      // param and reaches each handler, which must answer 404. This is distinct
+      // from a 422 (malformed UUID) or 405 (wrong method on a missing route),
+      // so it confirms the route templates resolve and the not-found branch is
+      // wired for all three goal endpoints.
+      const client = new ConversationClient({ host: config.agentServerUrl });
+      const missingId = '00000000-0000-0000-0000-000000000000';
+      try {
+        const calls: Array<() => Promise<unknown>> = [
+          () => client.startGoal(missingId, { objective: 'noop' }),
+          () => client.resumeGoal(missingId),
+          () => client.stopGoal(missingId),
+        ];
+        for (const call of calls) {
+          let status: number | undefined;
+          try {
+            await call();
+          } catch (error) {
+            expect(error).toBeInstanceOf(HttpError);
+            status = (error as HttpError).status;
+          }
+          expect(status).toBe(404);
+        }
+      } finally {
+        client.close();
       }
     },
     config.testTimeout

--- a/src/client/conversation-client.ts
+++ b/src/client/conversation-client.ts
@@ -14,6 +14,7 @@ import type {
   ForkConversationRequest,
   SetConfirmationPolicyRequest,
   SetSecurityAnalyzerRequest,
+  StartGoalRequest,
   UpdateConversationRequest,
   UpdateSecretsRequest,
 } from '../models/conversation';
@@ -172,6 +173,48 @@ export class ConversationClient {
   async runConversation(conversationId: string): Promise<Success> {
     const response = await this.client.post<Success>(
       `/api/conversations/${conversationId}/run`,
+      {}
+    );
+    return response.data;
+  }
+
+  /**
+   * Start a `/goal` loop inside an existing conversation. The loop runs in the
+   * conversation's own history and event stream (it does not fork). The server
+   * returns 409 if a run or goal loop is already active and 400 for an invalid
+   * objective (e.g. empty); a missing conversation yields 404.
+   */
+  async startGoal(conversationId: string, request: StartGoalRequest): Promise<Success> {
+    const response = await this.client.post<Success>(
+      `/api/conversations/${conversationId}/goal`,
+      request
+    );
+    return response.data;
+  }
+
+  /**
+   * Stop the active `/goal` loop in this conversation. Cancels only the
+   * background goal loop (not the conversation) and records an `interrupted`
+   * status so {@link resumeGoal} can continue it. Succeeds even when no loop is
+   * running; a missing conversation yields 404.
+   */
+  async stopGoal(conversationId: string): Promise<Success> {
+    const response = await this.client.post<Success>(
+      `/api/conversations/${conversationId}/goal/stop`,
+      {}
+    );
+    return response.data;
+  }
+
+  /**
+   * Resume the last interrupted `/goal` loop in this conversation. The server
+   * returns 409 if a run or goal loop is already active and 400 when there is
+   * no resumable goal (none started, or it already completed); a missing
+   * conversation yields 404.
+   */
+  async resumeGoal(conversationId: string): Promise<Success> {
+    const response = await this.client.post<Success>(
+      `/api/conversations/${conversationId}/goal/resume`,
       {}
     );
     return response.data;

--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -31,6 +31,7 @@ import {
   SetSecurityAnalyzerRequest,
   AgentResponseResult,
   ForkConversationRequest,
+  StartGoalRequest,
 } from '../models/conversation';
 import { IConversation, BaseConversationOptions } from './base';
 import { Success } from '../types/base';
@@ -302,6 +303,40 @@ export class RemoteConversation implements IConversation {
    */
   async switchAcpModel(model: string): Promise<void> {
     await this.client.post(`/api/conversations/${this.id}/switch_acp_model`, { model });
+  }
+
+  /**
+   * Start a `/goal` loop inside this conversation: the agent pursues the
+   * objective and is re-prompted after each run until a judge marks it done or
+   * `maxIterations` is reached. The loop runs in this conversation's history and
+   * event stream — it does not fork. Throws on 409 if a run or goal loop is
+   * already active, and on 400 for an invalid objective (e.g. empty).
+   */
+  async startGoal(objective: string, maxIterations?: number): Promise<void> {
+    const request: StartGoalRequest = { objective };
+    if (maxIterations !== undefined) {
+      request.max_iterations = maxIterations;
+    }
+    await this.client.post(`/api/conversations/${this.id}/goal`, request);
+  }
+
+  /**
+   * Stop the active `/goal` loop in this conversation. Cancels only the
+   * background goal loop (not the conversation) and records an `interrupted`
+   * status so {@link resumeGoal} can continue it. Succeeds even when no loop is
+   * currently running.
+   */
+  async stopGoal(): Promise<void> {
+    await this.client.post(`/api/conversations/${this.id}/goal/stop`, {});
+  }
+
+  /**
+   * Resume the last interrupted `/goal` loop in this conversation, continuing
+   * from the iteration it had reached. Throws on 409 if a run or goal loop is
+   * already active, and on 400 when there is no resumable goal.
+   */
+  async resumeGoal(): Promise<void> {
+    await this.client.post(`/api/conversations/${this.id}/goal/resume`, {});
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,7 @@ export type {
   ACPConversationSearchResponse,
   AskAgentRequest,
   AskAgentResponse,
+  StartGoalRequest,
   SetSecurityAnalyzerRequest,
   SetConfirmationPolicyRequest,
   ConversationEventSearchOptions,

--- a/src/models/conversation.ts
+++ b/src/models/conversation.ts
@@ -154,6 +154,23 @@ export interface AskAgentRequest {
   question: string;
 }
 
+/**
+ * Payload to start a `/goal` loop inside a conversation.
+ *
+ * Mirrors the agent-server's `StartGoalRequest`. The loop appends messages and
+ * runs the agent in the same conversation history/event stream as the main
+ * chat; it does not fork or create a separate conversation.
+ */
+export interface StartGoalRequest {
+  /** The goal objective to pursue and audit. Must not be empty server-side. */
+  objective: string;
+  /**
+   * Maximum audit rounds before giving up. Server requires `>= 1` and defaults
+   * to `10` when omitted.
+   */
+  max_iterations?: number;
+}
+
 export interface AskAgentResponse {
   response: string;
 }


### PR DESCRIPTION
## What

Adds TypeScript client support for the agent-server's goal-loop routes (added in [software-agent-sdk #3770](https://github.com/OpenHands/software-agent-sdk/pull/3770), released in **v1.29.0** — the image this repo pins):

- `POST /api/conversations/{id}/goal` — start a `/goal` loop
- `POST /api/conversations/{id}/goal/stop` — stop the active loop
- `POST /api/conversations/{id}/goal/resume` — resume the last interrupted loop

A `/goal` loop runs the agent against an objective and re-prompts after each run, judging completion until done or `max_iterations` is reached. It stays in the conversation's own history/event stream — it does **not** fork or create a separate conversation.

## Changes

- **Model**: `StartGoalRequest` (`objective: string`, optional `max_iterations`) added to `src/models/conversation.ts` and exported from the package root, mirroring the server's `StartGoalRequest` (objective non-empty, `max_iterations >= 1`, default `10`).
- **`ConversationClient`**: `startGoal(id, request)`, `stopGoal(id)`, `resumeGoal(id)` returning `Success`.
- **`RemoteConversation`**: `startGoal(objective, maxIterations?)`, `stopGoal()`, `resumeGoal()` — same layering as `switchAcpModel`. `maxIterations` is only sent when provided, so the server default applies otherwise.

## Server contract (from `conversation_router.py` @ v1.29.0)

| Route | Success | 409 | 400 | 404 |
|---|---|---|---|---|
| `/goal` | `Success` | run/goal already running | invalid objective (e.g. empty) | unknown conversation |
| `/goal/stop` | `Success` (no-op when idle) | — | — | unknown conversation |
| `/goal/resume` | `Success` | run/goal already running | `no_resumable_goal` | unknown conversation |

## Tests

**Unit (error paths, mocked `fetch`)** — `src/__tests__/api-clients.test.ts`: for both `ConversationClient` and `RemoteConversation`, assert the request path/method/body on the wire and that `409`, `400`, and `404` surface as `HttpError` with the right status. `max_iterations` is verified to be included only when supplied.

**Integration (deterministic, no LLM)** — `src/__tests__/integration/deterministic-api.integration.test.ts`, two contract guards run by `test:integration:deterministic`:
1. Against a real (dummy-agent) conversation: empty objective → `400`, resume with nothing → `400`, stop with no active loop → `200`. A `400`/`200` (not `404`) proves each route exists on the pinned image and the client targets the correct path/method/body.
2. For a well-formed but non-existent conversation UUID: all three → `404` (distinct from `422`/`405`), confirming the route templates resolve and the not-found branch is wired.

These deliberately avoid the happy path so they need neither a real LLM nor a spawned background loop.

## Verification

`npm run lint` (0 errors), `npm run build`, `npm run test:coverage` (267 passed), and `npm run format:check` all pass. The deterministic integration suite was run against `ghcr.io/openhands/agent-server:1.29.0-python` (9/9 passed, including the 2 new goal tests).