### PR TITLE
ci: add release ready gate

### DIFF
--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -1,0 +1,18 @@
+name: release ready
+
+on:
+  pull_request_target:
+    types: [ready_for_review]
+
+jobs:
+  release-ready:
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: write
+    secrets: inherit
+    uses: OpenHands/release-actions/.github/workflows/release-ready.yml@main
+    with:
+      product-name: TypeScript Client
+      slack-channel: '#proj-agent-canvas'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
+  "draft-pull-request": true,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- Adds the consumer-owned `pull_request_target.ready_for_review` caller workflow for release PRs.
- The caller delegates to `OpenHands/release-actions/.github/workflows/release-ready.yml@main` with:
  - `product-name: TypeScript Client`
  - `slack-channel: "#proj-agent-canvas"`
- Sets `"draft-pull-request": true` in `release-please-config.json` so release-please opens release PRs as drafts. Marking the draft PR **Ready for review** is the release-cut signal.

## How the split works
- This repo owns the GitHub event subscription because `ready_for_review` is emitted in the repo that owns the PR.
- `OpenHands/release-actions` owns the reusable implementation: release-please PR detection, `release: ready` labeling, Slack notification, and optional release-test dispatching.
- The caller only passes repo-specific policy: product name and Slack channel.

## Dependency
- Depends on `OpenHands/release-actions#13` landing first.

## Validation
- `npx --yes prettier@3.6.2 --check ...` on touched workflow/config files
- `git diff --check`

_This PR was created by an AI agent (OpenHands) on behalf of the user._
