### PR TITLE
chore: use conventional 'chore' prefix for Dependabot PR titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     assignees:
       - "All-Hands-AI/core-team"
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
     groups:
       typescript:


### PR DESCRIPTION
## What

Change the Dependabot `commit-message.prefix` in `.github/dependabot.yml` from `deps` to `chore`.

```diff
     commit-message:
-      prefix: "deps"
+      prefix: "chore"
       include: "scope"
```

## Why

The `pr` workflow lints PR titles against Conventional Commits via `OpenHands/release-actions/.github/workflows/pr-title.yml`, which only allows these types:

`feat fix perf docs chore build ci refactor style test revert`

`deps` is **not** an allowed type, so Dependabot's titles (e.g. `deps(deps-dev): bump typescript-eslint from 8.59.3 to 8.62.0`) fail the title lint and never receive a `type:` label (which drives release-notes grouping and release-please versioning).

With this change, future Dependabot PRs are titled:

- `chore(deps): bump …` (production deps)
- `chore(deps-dev): bump …` (dev deps)

Both pass the lint and get a `type: chore` label automatically. (`include: "scope"` is kept, so the `(deps)` / `(deps-dev)` scope is preserved.)

## Notes

- Only affects **newly opened** Dependabot PRs after this merges. Existing open PRs keep their current title until edited or recreated with `@dependabot recreate`.