### PR TITLE
feat(client): add InitClient for the deferred-init endpoints

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -19,6 +19,7 @@ import {
   ConversationClient,
   FileClient,
   HooksClient,
+  InitClient,
   isAgentServerVersionError,
   LLMMetadataClient,
   MCPClient,
@@ -2103,5 +2104,71 @@ describe('Auxiliary API clients', () => {
       'http://example.com/api/shared-events/search?conversation_id=shared-1&limit=50',
       expect.objectContaining({ method: 'GET' })
     );
+  });
+
+  it('ConversationManager exposes the init namespace', () => {
+    const manager = new ConversationManager({ host: 'http://example.com', apiKey: 'secret' });
+
+    expect(manager.init).toBeInstanceOf(InitClient);
+    expect(manager.init.host).toBe('http://example.com');
+    expect(manager.init.apiKey).toBe('secret');
+  });
+
+  it('InitClient.getStatus GETs /api/init', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ state: 'dormant', error: null }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new InitClient({ host: 'http://example.com' });
+    const status = await client.getStatus();
+
+    expect(status.state).toBe('dormant');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/init',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('InitClient.initialize POSTs /api/init with the X-Init-API-Key header and body', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ state: 'ready', error: null }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new InitClient({ host: 'http://example.com' });
+    const status = await client.initialize(
+      { session_api_keys: ['user-key'], max_concurrent_runs: 4 },
+      { initApiKey: 'bootstrap-secret' }
+    );
+
+    expect(status.state).toBe('ready');
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('http://example.com/api/init');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(
+      JSON.stringify({ session_api_keys: ['user-key'], max_concurrent_runs: 4 })
+    );
+    expect((init.headers as Record<string, string>)['X-Init-API-Key']).toBe('bootstrap-secret');
+  });
+
+  it('InitClient.initialize omits the X-Init-API-Key header when no key is given', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ state: 'ready', error: null }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new InitClient({ host: 'http://example.com' });
+    await client.initialize();
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.body).toBe(JSON.stringify({}));
+    expect((init.headers as Record<string, string>)['X-Init-API-Key']).toBeUndefined();
   });
 });

--- a/src/__tests__/integration/deterministic-api.integration.test.ts
+++ b/src/__tests__/integration/deterministic-api.integration.test.ts
@@ -391,4 +391,33 @@ describe('Deterministic API Integration Tests', () => {
     },
     config.testTimeout
   );
+
+  it(
+    'reaches the deferred-init routes and reports not-deferred with 404',
+    async () => {
+      // The pinned image runs in the normal (non-deferred) mode, so no
+      // InitService is registered and both /api/init routes answer 404 via
+      // get_init_service. A 404 (not a 405/422) proves the GET and POST routes
+      // exist on the image AND that the client targets the right path/method —
+      // client<->server contract drift the mocked unit tests cannot catch.
+      let getStatus: number | undefined;
+      try {
+        await manager.init.getStatus();
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpError);
+        getStatus = (error as HttpError).status;
+      }
+      expect(getStatus).toBe(404);
+
+      let postStatus: number | undefined;
+      try {
+        await manager.init.initialize({ session_api_keys: ['noop'] });
+      } catch (error) {
+        expect(error).toBeInstanceOf(HttpError);
+        postStatus = (error as HttpError).status;
+      }
+      expect(postStatus).toBe(404);
+    },
+    config.testTimeout
+  );
 });

--- a/src/client/init-client.ts
+++ b/src/client/init-client.ts
@@ -1,0 +1,80 @@
+import { HttpClient } from './http-client';
+import type { InitRequest, InitStatus } from '../models/api';
+
+export interface InitClientOptions {
+  host: string;
+  apiKey?: string;
+  timeout?: number;
+}
+
+export interface InitializeOptions {
+  /**
+   * Bootstrap credential sent as the `X-Init-API-Key` header. This is distinct
+   * from the per-session `X-Session-API-Key`: the orchestrator already holds the
+   * dormant server's `secret_key` (needed for encryption) and uses it to
+   * authorize the one-time init call. When the dormant server has no
+   * `secret_key`, the endpoint is open and this can be omitted.
+   */
+  initApiKey?: string;
+}
+
+/**
+ * Client for the deferred-init endpoints of a warm-pool agent-server.
+ *
+ * When the server is started with `deferred_init=True` it boots in a *dormant*
+ * state: stateless services come up but every `/api/*` route returns 503 until
+ * `POST /api/init` delivers the per-user runtime configuration. These endpoints
+ * are mounted unconditionally, but a non-deferred server answers them with 404
+ * (no `InitService` registered).
+ *
+ * See: https://github.com/OpenHands/software-agent-sdk/issues/2523
+ */
+export class InitClient {
+  public readonly host: string;
+  public readonly apiKey?: string;
+  private readonly client: HttpClient;
+
+  constructor(options: InitClientOptions) {
+    this.host = options.host.replace(/\/$/, '');
+    this.apiKey = options.apiKey;
+    this.client = new HttpClient({
+      baseUrl: this.host,
+      apiKey: this.apiKey,
+      timeout: options.timeout || 60000,
+    });
+  }
+
+  /**
+   * Report the current deferred-init state via `GET /api/init`.
+   *
+   * Authentication is intentionally not required so a warm-pool controller can
+   * poll without holding the init key. Returns 404 when the server is not
+   * running in deferred-init mode.
+   */
+  async getStatus(): Promise<InitStatus> {
+    const response = await this.client.get<InitStatus>('/api/init');
+    return response.data;
+  }
+
+  /**
+   * Initialize a dormant server with runtime configuration via `POST /api/init`.
+   *
+   * Returns the resulting {@link InitStatus} (`ready` on success). The server
+   * returns 400 if it has already been initialized, 401 if the init key is
+   * wrong, 404 if not running in deferred-init mode, and 500 (with the state
+   * rolled back to `dormant` for retry) if initialization fails.
+   */
+  async initialize(
+    request: InitRequest = {},
+    options: InitializeOptions = {}
+  ): Promise<InitStatus> {
+    const response = await this.client.post<InitStatus>('/api/init', request, {
+      headers: options.initApiKey ? { 'X-Init-API-Key': options.initApiKey } : undefined,
+    });
+    return response.data;
+  }
+
+  close(): void {
+    this.client.close();
+  }
+}

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -5,6 +5,7 @@ export { CloudProxyClient } from './client/cloud-proxy-client';
 export { ConversationClient } from './client/conversation-client';
 export { FileClient } from './client/file-client';
 export { HooksClient } from './client/hooks-client';
+export { InitClient } from './client/init-client';
 export { LLMMetadataClient } from './client/llm-client';
 export { MCPClient } from './client/mcp-client';
 export { ProfilesClient } from './client/profiles-client';
@@ -38,6 +39,7 @@ export type {
 } from './client/conversation-client';
 export type { FileClientOptions, FileUploadContent } from './client/file-client';
 export type { HooksClientOptions } from './client/hooks-client';
+export type { InitClientOptions, InitializeOptions } from './client/init-client';
 export type { LLMMetadataClientOptions } from './client/llm-client';
 export type { MCPClientOptions } from './client/mcp-client';
 export type { ProfilesClientOptions, GetProfileOptions } from './client/profiles-client';

--- a/src/conversation/conversation-manager.ts
+++ b/src/conversation/conversation-manager.ts
@@ -8,6 +8,7 @@ import { CloudProxyClient } from '../client/cloud-proxy-client';
 import { DesktopClient } from '../client/desktop-client';
 import { FileClient } from '../client/file-client';
 import { HooksClient } from '../client/hooks-client';
+import { InitClient } from '../client/init-client';
 import { LLMMetadataClient } from '../client/llm-client';
 import { MCPClient } from '../client/mcp-client';
 import { ProfilesClient } from '../client/profiles-client';
@@ -96,6 +97,7 @@ export class ConversationManager {
   public readonly hooks: HooksClient;
   public readonly mcp: MCPClient;
   public readonly cloudProxy: CloudProxyClient;
+  public readonly init: InitClient;
   public readonly acp: ACPConversationNamespace;
 
   constructor(options: ConversationManagerOptions) {
@@ -129,6 +131,7 @@ export class ConversationManager {
     this.hooks = new HooksClient(clientOptions);
     this.mcp = new MCPClient(clientOptions);
     this.cloudProxy = new CloudProxyClient(clientOptions);
+    this.init = new InitClient(clientOptions);
     this.acp = new ACPConversationNamespace(this);
   }
 
@@ -413,6 +416,7 @@ export class ConversationManager {
     this.hooks.close();
     this.mcp.close();
     this.cloudProxy.close();
+    this.init.close();
     this.client.close();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,6 +373,9 @@ export type {
   MCPTestResponse,
   SharedConversation,
   EventPage as ApiEventPage,
+  InitState,
+  InitStatus,
+  InitRequest,
 } from './models/api';
 
 export type { WebSocketClientOptions } from './events/websocket-client';

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -483,3 +483,43 @@ export interface EventPage<TEvent = unknown> {
   items: TEvent[];
   next_page_id: string | null;
 }
+
+/**
+ * Deferred-init lifecycle state of a warm-pool agent-server.
+ * - `dormant` — up but waiting for `POST /api/init`.
+ * - `initializing` — `/api/init` received, services starting.
+ * - `ready` — initialization complete; all `/api/*` routes are live.
+ */
+export type InitState = 'dormant' | 'initializing' | 'ready';
+
+export interface InitStatus {
+  state: InitState;
+  /** Error message from a previous failed `/api/init` attempt, if any. */
+  error?: string | null;
+}
+
+/**
+ * Runtime configuration delivered to a dormant server at `POST /api/init`.
+ * Every field is optional and overrides the equivalent field on the dormant
+ * `Config`; omitted fields keep the value the server booted with.
+ */
+export interface InitRequest {
+  /** Per-user session API keys enforced on subsequent `/api/*` requests. */
+  session_api_keys?: string[] | null;
+  /** Symmetric secret used to encrypt persisted secrets. */
+  secret_key?: string | null;
+  /** Directory where conversations are persisted. */
+  conversations_path?: string | null;
+  /** Directory where bash events are persisted. */
+  bash_events_dir?: string | null;
+  /** Per-user webhooks (e.g. for streaming events back). */
+  webhooks?: unknown[] | null;
+  /** External URL where this server is reachable (root-path calculation). */
+  web_url?: string | null;
+  /** CORS origins to add to the existing localhost allowlist. */
+  allow_cors_origins?: string[] | null;
+  /** Override the conversation-step concurrency limit. */
+  max_concurrent_runs?: number | null;
+  /** Process environment variables to set before conversation services start. */
+  env?: Record<string, string> | null;
+}


### PR DESCRIPTION
## Summary

Split from #231 (one feature per PR). Adds client coverage for the warm-pool deferred-init endpoints that the audit reported as missing. Implementations follow the agent-server init router in `OpenHands/software-agent-sdk` (see [software-agent-sdk#2523](https://github.com/OpenHands/software-agent-sdk/issues/2523)).

| Endpoint | Status before | Change |
|---|---|---|
| `GET /api/init` | missing | **new** `InitClient.getStatus()` |
| `POST /api/init` | missing | **new** `InitClient.initialize()` (sends `X-Init-API-Key`) |

## Details

- New `src/client/init-client.ts` wraps the deferred-init / warm-pool endpoints. `POST /api/init` authenticates with the bootstrap `X-Init-API-Key` header (distinct from the per-session `X-Session-API-Key`); it is omitted when no key is given.
- Model types `InitState` / `InitStatus` / `InitRequest` added to `models/api.ts` and exported from `index.ts`.
- `InitClient` exported from `clients.ts` and wired into `ConversationManager` as the `init` namespace (constructed and closed alongside the other clients).

## Testing

- **Unit** (`src/__tests__/api-clients.test.ts`, mocked `fetch`): `init` namespace wiring, `getStatus` GET, `initialize` POST (header + body present), and `initialize` omitting the header when no key is given.
- **Integration** (`deterministic-api.integration.test.ts`): both routes return `404` on the non-deferred pinned image (`get_init_service` answers 404 when no `InitService` is registered) — proving the GET/POST routes exist on the image and the client targets the right path/method.
- `npm run build`, `lint` (0 errors), and `format:check` pass; full unit suite green (273).