### PR TITLE
feat(client): serve conversation workspace static files

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -2104,4 +2104,32 @@ describe('Auxiliary API clients', () => {
       expect.objectContaining({ method: 'GET' })
     );
   });
+
+  it('ConversationClient workspace methods serve the static file routes as blobs', async () => {
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response('<html>workspace</html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        })
+      )
+    ) as typeof fetch;
+
+    const client = new ConversationClient({ host: 'http://example.com' });
+    const root = await client.getWorkspaceRoot('c1');
+    const file = await client.getWorkspaceFile('c1', 'sub/dir/page.html');
+
+    expect(root).toBeInstanceOf(Blob);
+    expect(await file.text()).toBe('<html>workspace</html>');
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://example.com/api/conversations/c1/workspace',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://example.com/api/conversations/c1/workspace/sub/dir/page.html',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
 });

--- a/src/__tests__/integration/deterministic-api.integration.test.ts
+++ b/src/__tests__/integration/deterministic-api.integration.test.ts
@@ -8,6 +8,7 @@ import {
   uniqueDirName,
   uniqueFileName,
   workspaceFileExists,
+  writeWorkspaceFile,
 } from './test-utils';
 
 const config = getServerTestConfig();
@@ -386,6 +387,52 @@ describe('Deterministic API Integration Tests', () => {
           expect(status).toBe(404);
         }
       } finally {
+        client.close();
+      }
+    },
+    config.testTimeout
+  );
+
+  it(
+    'serves conversation workspace files over the static workspace routes',
+    async () => {
+      // Exercises GET /api/conversations/{id}/workspace (root index.html) and
+      // GET /api/conversations/{id}/workspace/{file_path}. The conversation's
+      // working dir is the mounted workspace, so files written there are served
+      // back verbatim through the static routes.
+      const client = new ConversationClient({ host: config.agentServerUrl });
+      const conversation = await manager.createConversation(createDummyAgent(), {
+        workingDir: config.agentWorkspaceDir,
+      });
+      const rootIndex = 'index.html';
+      const nestedDir = uniqueDirName('ws-serve');
+      const nestedFile = `${nestedDir}/page.html`;
+      const rootContent = '<html><body>workspace root</body></html>';
+      const nestedContent = '<html><body>nested workspace page</body></html>';
+      try {
+        writeWorkspaceFile(rootIndex, rootContent);
+        writeWorkspaceFile(nestedFile, nestedContent);
+        await sleep(300);
+
+        const servedRoot = await client.getWorkspaceRoot(conversation.id);
+        const servedFile = await client.getWorkspaceFile(conversation.id, nestedFile);
+        expect(servedRoot).toBeInstanceOf(Blob);
+        expect(await servedRoot.text()).toBe(rootContent);
+        expect(await servedFile.text()).toBe(nestedContent);
+
+        // A file the workspace does not contain yields 404.
+        let missingStatus: number | undefined;
+        try {
+          await client.getWorkspaceFile(conversation.id, `${nestedDir}/missing.html`);
+        } catch (error) {
+          expect(error).toBeInstanceOf(HttpError);
+          missingStatus = (error as HttpError).status;
+        }
+        expect(missingStatus).toBe(404);
+      } finally {
+        deleteWorkspaceFile(rootIndex);
+        await workspace.executeCommand(`rm -rf ${config.agentWorkspaceDir}/${nestedDir}`);
+        await manager.deleteConversation(conversation.id).catch(() => undefined);
         client.close();
       }
     },

--- a/src/client/conversation-client.ts
+++ b/src/client/conversation-client.ts
@@ -356,6 +356,39 @@ export class ConversationClient {
     return response.data;
   }
 
+  /**
+   * Fetch the conversation workspace root (`index.html`) served as a static
+   * file by `GET /api/conversations/{id}/workspace`.
+   *
+   * The agent-server only serves *local* workspaces; non-local workspaces, a
+   * missing directory, or the absence of an `index.html` all yield 404. The
+   * raw bytes are returned as a {@link Blob} so binary artifacts survive intact
+   * (call `.text()` for HTML/text).
+   */
+  async getWorkspaceRoot(conversationId: string): Promise<Blob> {
+    const response = await this.client.get<Blob>(`/api/conversations/${conversationId}/workspace`, {
+      responseType: 'blob',
+    });
+    return response.data;
+  }
+
+  /**
+   * Fetch a single file (or a directory's `index.html`) from the conversation
+   * workspace via `GET /api/conversations/{id}/workspace/{filePath}`.
+   *
+   * `filePath` is a workspace-relative path; nested paths are supported. Paths
+   * that escape the workspace are rejected by the server with 400, and a
+   * missing file/conversation yields 404. The raw bytes are returned as a
+   * {@link Blob} so binary artifacts survive intact (call `.text()` for text).
+   */
+  async getWorkspaceFile(conversationId: string, filePath: string): Promise<Blob> {
+    const response = await this.client.get<Blob>(
+      `/api/conversations/${conversationId}/workspace/${filePath}`,
+      { responseType: 'blob' }
+    );
+    return response.data;
+  }
+
   close(): void {
     this.client.close();
   }


### PR DESCRIPTION
## Summary

Split from #231 (one feature per PR). Adds client coverage for the agent-server's static workspace-serving routes, which the audit reported as missing.

| Endpoint | Status before | Change |
|---|---|---|
| `GET /api/conversations/{id}/workspace` | missing | **new** `ConversationClient.getWorkspaceRoot()` |
| `GET /api/conversations/{id}/workspace/{path}` | missing | **new** `ConversationClient.getWorkspaceFile()` |

## Details

- Both methods return the raw bytes as a `Blob` (call `.text()` for HTML/text) so binary artifacts survive intact, matching `FileClient.downloadTrajectory`.
- `getWorkspaceRoot` serves the workspace root `index.html`; `getWorkspaceFile` serves a workspace-relative file (nested paths supported). The agent-server only serves *local* workspaces — non-local workspaces, a missing directory/file, or the absence of `index.html` yield 404; path traversal is rejected with 400.

## Testing

- **Unit** (`src/__tests__/api-clients.test.ts`, mocked `fetch`): both routes are GET, return a `Blob`, and round-trip text content; asserts the exact URLs (including the nested path).
- **Integration** (`deterministic-api.integration.test.ts`): writes a root `index.html` and a nested file into the mounted workspace, serves both back verbatim through the static routes, and asserts `404` for a missing file.
- `npm run build`, `lint` (0 errors), and `format:check` pass; full unit suite green.