### PR TITLE
feat(client): add BashClient.batchGetEvents server-side batch endpoint

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -31,8 +31,48 @@ import {
   SkillsClient,
   WorkspacesClient,
 } from '../clients';
+import * as http from 'node:http';
+import { EventEmitter } from 'node:events';
+
+// `fetch` rejects a GET body, so the batch endpoints route through node:http.
+// Its `request` export isn't configurable (jest.spyOn fails), so mock the module.
+jest.mock('node:http', () => ({
+  ...jest.requireActual('node:http'),
+  request: jest.fn(),
+}));
 
 const originalFetch = global.fetch;
+
+/**
+ * Drive the mocked Node `http.request` for the GET-with-body transport path used
+ * by the batch endpoints. Captures the request URL/options/body and replays a
+ * canned JSON response.
+ */
+function mockNodeHttpRequest(responseBody: string, status = 200) {
+  const captured: { url?: URL; options?: http.RequestOptions; body?: string } = {};
+  (http.request as jest.Mock).mockImplementation((url: unknown, options: unknown, cb: unknown) => {
+    captured.url = url as URL;
+    captured.options = options as http.RequestOptions;
+    const callback = cb as (res: http.IncomingMessage) => void;
+    const req = new EventEmitter() as unknown as http.ClientRequest;
+    (req as unknown as { setTimeout: unknown }).setTimeout = jest.fn();
+    (req as unknown as { destroy: unknown }).destroy = jest.fn();
+    (req as unknown as { end: unknown }).end = jest.fn((body?: string) => {
+      captured.body = body;
+      process.nextTick(() => {
+        const res = new EventEmitter() as unknown as http.IncomingMessage;
+        res.statusCode = status;
+        res.statusMessage = status === 200 ? 'OK' : 'Error';
+        res.headers = { 'content-type': 'application/json' };
+        callback(res);
+        res.emit('data', Buffer.from(responseBody));
+        res.emit('end');
+      });
+    });
+    return req;
+  });
+  return { captured };
+}
 
 describe('Auxiliary API clients', () => {
   afterEach(() => {
@@ -2103,5 +2143,21 @@ describe('Auxiliary API clients', () => {
       'http://example.com/api/shared-events/search?conversation_id=shared-1&limit=50',
       expect.objectContaining({ method: 'GET' })
     );
+  });
+
+  it('BashClient.batchGetEvents GETs the batch endpoint with the event ids in the body', async () => {
+    const events = [{ id: 'e1', kind: 'BashOutput', timestamp: '2026-05-23T12:00:00Z' }, null];
+    // `fetch` rejects a GET body, so the batch endpoint goes through node:http.
+    const { captured } = mockNodeHttpRequest(JSON.stringify(events));
+
+    const client = new BashClient({ host: 'http://example.com' });
+    const result = await client.batchGetEvents(['e1', 'missing']);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.id).toBe('e1');
+    expect(result[1]).toBeNull();
+    expect(captured.options?.method).toBe('GET');
+    expect(captured.url?.toString()).toBe('http://example.com/api/bash/bash_events/');
+    expect(JSON.parse(captured.body ?? 'null')).toEqual(['e1', 'missing']);
   });
 });

--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -2147,7 +2147,6 @@ describe('Auxiliary API clients', () => {
 
   it('BashClient.batchGetEvents GETs the batch endpoint with the event ids in the body', async () => {
     const events = [{ id: 'e1', kind: 'BashOutput', timestamp: '2026-05-23T12:00:00Z' }, null];
-    // `fetch` rejects a GET body, so the batch endpoint goes through node:http.
     const { captured } = mockNodeHttpRequest(JSON.stringify(events));
 
     const client = new BashClient({ host: 'http://example.com' });

--- a/src/__tests__/integration/bash.integration.test.ts
+++ b/src/__tests__/integration/bash.integration.test.ts
@@ -35,12 +35,22 @@ describe('Bash API Integration Tests', () => {
 
       const fetchedCommand = await bash.getEvent(command.id);
       const batch = await bash.getEvents([command.id, outputEvent!.id]);
+      // Server-side batch endpoint (GET /api/bash/bash_events/). Includes a
+      // bogus id to confirm missing items come back as null in place.
+      const serverBatch = await bash.batchGetEvents([
+        command.id,
+        'does-not-exist',
+        outputEvent!.id,
+      ]);
       const executeResult = await bash.executeCommand('printf "bash-execute-test"');
       const cleared = await bash.clearEvents();
 
       expect(fetchedCommand.id).toBe(command.id);
       expect(batch[0]?.id).toBe(command.id);
       expect(batch[1]?.id).toBe(outputEvent!.id);
+      expect(serverBatch[0]?.id).toBe(command.id);
+      expect(serverBatch[1]).toBeNull();
+      expect(serverBatch[2]?.id).toBe(outputEvent!.id);
       expect(outputEvent?.stdout).toContain('bash-search-test');
       expect(executeResult.stdout).toContain('bash-execute-test');
       expect(cleared.cleared_count).toBeGreaterThanOrEqual(1);

--- a/src/client/bash-client.ts
+++ b/src/client/bash-client.ts
@@ -57,6 +57,20 @@ export class BashClient {
     );
   }
 
+  /**
+   * Batch-fetch bash events in a single request via `GET /api/bash/bash_events/`.
+   *
+   * Unlike {@link getEvents} (which fans out one request per id), this calls the
+   * server-side batch endpoint and returns one entry per requested id, with
+   * `null` in the slots of any missing event — preserving input order.
+   */
+  async batchGetEvents(eventIds: string[]): Promise<Array<BashEvent | null>> {
+    const response = await this.client.get<(BashEvent | null)[]>('/api/bash/bash_events/', {
+      data: eventIds,
+    });
+    return response.data;
+  }
+
   async startCommand(
     request: string | ExecuteBashRequest,
     cwd?: string,

--- a/src/client/http-client.ts
+++ b/src/client/http-client.ts
@@ -58,6 +58,25 @@ export class HttpClient {
     this.timeout = options.timeout || 60000;
   }
 
+  private buildUrl(path: string, params?: Record<string, unknown>): URL {
+    const relativePath = path.startsWith('/') ? path.slice(1) : path;
+    const url = new URL(relativePath, this.baseUrl + '/');
+
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          if (Array.isArray(value)) {
+            value.forEach((item) => url.searchParams.append(key, String(item)));
+          } else {
+            url.searchParams.append(key, String(value));
+          }
+        }
+      });
+    }
+
+    return url;
+  }
+
   async request<T = unknown>(options: RequestOptions): Promise<HttpResponse<T>> {
     // `fetch` (and browsers) reject a body on a GET request, but a few
     // agent-server batch endpoints (e.g. `GET /api/bash/bash_events/` and
@@ -68,20 +87,7 @@ export class HttpClient {
       return this.requestWithBodyOnGet<T>(options);
     }
 
-    const relativePath = options.url.startsWith('/') ? options.url.slice(1) : options.url;
-    const url = new URL(relativePath, this.baseUrl + '/');
-
-    if (options.params) {
-      Object.entries(options.params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          if (Array.isArray(value)) {
-            value.forEach((item) => url.searchParams.append(key, String(item)));
-          } else {
-            url.searchParams.append(key, String(value));
-          }
-        }
-      });
-    }
+    const url = this.buildUrl(options.url, options.params);
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -180,20 +186,7 @@ export class HttpClient {
   private async requestWithBodyOnGet<T = unknown>(
     options: RequestOptions
   ): Promise<HttpResponse<T>> {
-    const relativePath = options.url.startsWith('/') ? options.url.slice(1) : options.url;
-    const url = new URL(relativePath, this.baseUrl + '/');
-
-    if (options.params) {
-      Object.entries(options.params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          if (Array.isArray(value)) {
-            value.forEach((item) => url.searchParams.append(key, String(item)));
-          } else {
-            url.searchParams.append(key, String(value));
-          }
-        }
-      });
-    }
+    const url = this.buildUrl(options.url, options.params);
 
     const body = typeof options.data === 'string' ? options.data : JSON.stringify(options.data);
 

--- a/src/client/http-client.ts
+++ b/src/client/http-client.ts
@@ -59,6 +59,15 @@ export class HttpClient {
   }
 
   async request<T = unknown>(options: RequestOptions): Promise<HttpResponse<T>> {
+    // `fetch` (and browsers) reject a body on a GET request, but a few
+    // agent-server batch endpoints (e.g. `GET /api/bash/bash_events/` and
+    // `GET /api/conversations/{id}/events`) are declared as GET-with-required-body.
+    // Route those through Node's http(s) module, which permits a GET body, and
+    // leave the fetch path untouched for every other request.
+    if (options.method === 'GET' && options.data !== undefined && options.data !== null) {
+      return this.requestWithBodyOnGet<T>(options);
+    }
+
     const relativePath = options.url.startsWith('/') ? options.url.slice(1) : options.url;
     const url = new URL(relativePath, this.baseUrl + '/');
 
@@ -159,6 +168,144 @@ export class HttpClient {
 
       throw new Error('Unknown request error', { cause: error });
     }
+  }
+
+  /**
+   * Issue a GET request that carries a JSON body via Node's `http`/`https`
+   * module. `fetch` throws `TypeError: Request with GET/HEAD method cannot have
+   * body`, so this is the only way to call the agent-server's GET-with-body
+   * batch endpoints. Mirrors the URL/header/error/parse behavior of the fetch
+   * path in {@link request}. Node-only by nature (browsers forbid GET bodies).
+   */
+  private async requestWithBodyOnGet<T = unknown>(
+    options: RequestOptions
+  ): Promise<HttpResponse<T>> {
+    const relativePath = options.url.startsWith('/') ? options.url.slice(1) : options.url;
+    const url = new URL(relativePath, this.baseUrl + '/');
+
+    if (options.params) {
+      Object.entries(options.params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          if (Array.isArray(value)) {
+            value.forEach((item) => url.searchParams.append(key, String(item)));
+          } else {
+            url.searchParams.append(key, String(value));
+          }
+        }
+      });
+    }
+
+    const body = typeof options.data === 'string' ? options.data : JSON.stringify(options.data);
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...options.headers,
+      'Content-Length': String(Buffer.byteLength(body)),
+    };
+
+    if (this.apiKey) {
+      headers['X-Session-API-Key'] = this.apiKey;
+    }
+
+    const transport =
+      url.protocol === 'https:' ? await import('node:https') : await import('node:http');
+    const timeoutMs = options.timeout || this.timeout;
+
+    return new Promise<HttpResponse<T>>((resolve, reject) => {
+      const req = transport.request(url, { method: options.method, headers }, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          try {
+            const status = res.statusCode ?? 0;
+            const statusText = res.statusMessage ?? '';
+            const responseHeaders: Record<string, string> = {};
+            for (const [key, value] of Object.entries(res.headers)) {
+              if (value !== undefined) {
+                responseHeaders[key] = Array.isArray(value) ? value.join(', ') : value;
+              }
+            }
+
+            const buffer = Buffer.concat(chunks);
+            const contentType = responseHeaders['content-type'];
+
+            const isAcceptable =
+              options.acceptableStatusCodes?.has(status) ||
+              (!options.acceptableStatusCodes && status >= 200 && status < 300);
+
+            if (!isAcceptable) {
+              const text = buffer.toString('utf-8');
+              let errorContent: unknown;
+              try {
+                errorContent = contentType?.includes('application/json') ? JSON.parse(text) : text;
+              } catch {
+                errorContent = text || null;
+              }
+
+              reject(
+                new HttpError(
+                  status,
+                  statusText,
+                  errorContent,
+                  `HTTP request failed (${status} ${statusText}): ${JSON.stringify(errorContent)}`
+                )
+              );
+              return;
+            }
+
+            const data = this.parseNodeResponse<T>(
+              buffer,
+              contentType,
+              options.responseType || 'auto'
+            );
+
+            resolve({ data, status, statusText, headers: responseHeaders });
+          } catch (error) {
+            reject(error);
+          }
+        });
+      });
+
+      req.on('error', (error: Error) => {
+        reject(new Error(`Request failed: ${error.message}`, { cause: error }));
+      });
+
+      req.setTimeout(timeoutMs, () => {
+        req.destroy(new Error(`Request timeout after ${timeoutMs}ms`));
+      });
+
+      req.end(body);
+    });
+  }
+
+  private parseNodeResponse<T>(
+    buffer: Buffer,
+    contentType: string | undefined,
+    responseType: ResponseType
+  ): T {
+    if (responseType === 'blob') {
+      return new Blob([new Uint8Array(buffer)]) as T;
+    }
+
+    if (responseType === 'arrayBuffer') {
+      return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as T;
+    }
+
+    const text = buffer.toString('utf-8');
+
+    if (responseType === 'text') {
+      return text as T;
+    }
+
+    if (responseType === 'json') {
+      return (text ? JSON.parse(text) : undefined) as T;
+    }
+
+    if (contentType?.includes('application/json')) {
+      return (text ? JSON.parse(text) : undefined) as T;
+    }
+
+    return text as T;
   }
 
   private async parseResponse<T>(response: Response, responseType: ResponseType): Promise<T> {


### PR DESCRIPTION
## Summary

Split from #231 (one feature per PR). Adds client coverage for the server-side bash batch endpoint that the audit reported as missing.

| Endpoint | Status before | Change |
|---|---|---|
| `GET /api/bash/bash_events/` (batch) | missing | **new** `BashClient.batchGetEvents()` |

## Details

- This endpoint is declared **GET-with-required-body**, which `fetch` rejects (`TypeError: Request with GET/HEAD method cannot have body`). `HttpClient` now routes GET-with-body requests through Node's `http`/`https` module (`requestWithBodyOnGet` + `parseNodeResponse`), mirroring the fetch path's URL/header/error/parse behavior; **every other request is untouched**.
- Unlike `getEvents` (which fans out one request per id), `batchGetEvents` calls the server-side batch endpoint and returns one entry per requested id, with `null` in the slots of any missing event — preserving input order.

> Note: the GET-with-body `HttpClient` infrastructure here is shared with the conversation batch-events PR (split from the same audit). The two are intentionally identical so they merge cleanly.

## Testing

- **Unit** (`src/__tests__/api-clients.test.ts`): mocks `node:http` (the GET-body transport) and asserts the request method/URL/body and the null-for-missing mapping.
- **Integration** (`bash.integration.test.ts`): real event ids round-trip through the batch endpoint and a bogus id comes back as `null` in place.
- `npm run build`, `lint` (0 errors), and `format:check` pass; full unit suite green (270).