### PR TITLE
feat(client): add conversation navigate endpoint

### DIFF
--- a/src/__tests__/api-clients.test.ts
+++ b/src/__tests__/api-clients.test.ts
@@ -1591,6 +1591,116 @@ describe('Auxiliary API clients', () => {
     );
   });
 
+  it('ConversationClient.navigateConversation POSTs event_id and returns the re-rooted info', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'conversation-1', leaf_event_id: 'event-7' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new ConversationClient({ host: 'http://example.com' });
+    const info = await client.navigateConversation(
+      'conversation-1',
+      { event_id: 'event-7' },
+      { includeSkills: true }
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conversation-1/navigate?include_skills=true',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ event_id: 'event-7' }),
+      })
+    );
+    // The response carries the new HEAD.
+    expect(info.leaf_event_id).toBe('event-7');
+  });
+
+  it('ConversationClient.navigateConversation selects the empty tree with a null event_id', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'conversation-1', leaf_event_id: null }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as typeof fetch;
+
+    const client = new ConversationClient({ host: 'http://example.com' });
+    await client.navigateConversation('conversation-1', { event_id: null });
+
+    // No includeSkills option => no query string on the URL.
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conversation-1/navigate',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ event_id: null }),
+      })
+    );
+  });
+
+  it('RemoteConversation.navigateTo POSTs to /navigate then refreshes cached state', async () => {
+    // navigateTo posts to the route and then GETs the conversation to refresh
+    // the cache (leaf_event_id is not broadcast over the WebSocket). Two calls
+    // means each needs its own Response (a body can only be read once).
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ id: 'conv-123', leaf_event_id: 'event-3' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+    ) as typeof fetch;
+
+    const agent = new Agent({ llm: { model: 'gpt-4o', api_key: 'k' } });
+    const workspace = new RemoteWorkspace({ host: 'http://example.com', workingDir: '/tmp' });
+    const conversation = new RemoteConversation(agent, workspace, {
+      conversationId: 'conv-123',
+    });
+
+    await conversation.navigateTo('event-3');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conv-123/navigate',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ event_id: 'event-3' }),
+      })
+    );
+    // The trailing refresh re-reads the conversation from the REST API.
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conv-123',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('RemoteConversation.navigateTo passes a null event_id for the empty tree', async () => {
+    // Fresh Response per call: navigateTo posts and then refreshes state.
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ id: 'conv-123', leaf_event_id: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+    ) as typeof fetch;
+
+    const agent = new Agent({ llm: { model: 'gpt-4o', api_key: 'k' } });
+    const workspace = new RemoteWorkspace({ host: 'http://example.com', workingDir: '/tmp' });
+    const conversation = new RemoteConversation(agent, workspace, {
+      conversationId: 'conv-123',
+    });
+
+    await conversation.navigateTo(null);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/conversations/conv-123/navigate',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ event_id: null }),
+      })
+    );
+  });
+
   it('ConversationManager.switchProfile posts the profile name', async () => {
     global.fetch = jest.fn().mockResolvedValue(
       new Response(JSON.stringify({ success: true }), {

--- a/src/__tests__/integration/deterministic-api.integration.test.ts
+++ b/src/__tests__/integration/deterministic-api.integration.test.ts
@@ -410,4 +410,98 @@ describe('Deterministic API Integration Tests', () => {
     },
     config.testTimeout
   );
+
+  it(
+    'navigate re-roots the HEAD across existing events and back to the empty tree',
+    async () => {
+      // Contract + semantics guard for POST /api/conversations/{id}/navigate
+      // (software-agent-sdk #3923, released in v1.31.0 — the pinned image).
+      // Two user messages create >=2 events without an LLM; navigate then moves
+      // the conversation HEAD (leaf_event_id) across them in place — no fork, no
+      // new conversation. This proves the route exists on the image AND that the
+      // client targets the right path/body while carrying back the new leaf —
+      // client<->server contract drift the mocked unit tests cannot catch.
+      const client = new ConversationClient({ host: config.agentServerUrl });
+      const conversation = await manager.createConversation(createDummyAgent(), {
+        workingDir: config.agentWorkspaceDir,
+      });
+      try {
+        await conversation.sendMessage('First navigate message');
+        await conversation.sendMessage('Second navigate message');
+
+        // Ascending sort => items[0] is the earliest event, last is the tail.
+        const events = await conversation.state.events.search({
+          limit: 50,
+          sort_order: 'TIMESTAMP',
+        });
+        expect(events.items.length).toBeGreaterThanOrEqual(2);
+        const firstEventId = events.items[0].id;
+        const lastEventId = events.items[events.items.length - 1].id;
+
+        // Re-root HEAD onto the earliest event; the response carries the new leaf.
+        const rerooted = await client.navigateConversation(conversation.id, {
+          event_id: firstEventId,
+        });
+        expect(rerooted.leaf_event_id).toBe(firstEventId);
+
+        // A null event_id selects the empty tree (a deliberate new root).
+        const emptied = await client.navigateConversation(conversation.id, {
+          event_id: null,
+        });
+        expect(emptied.leaf_event_id).toBeNull();
+
+        // The high-level wrapper reaches the same route and refreshes cached
+        // state without throwing; restore the HEAD to the original tail and read
+        // it back off the server to prove the move persisted.
+        await conversation.navigateTo(lastEventId);
+        const restored = await manager.getConversations([conversation.id]);
+        expect(restored[0]?.leaf_event_id).toBe(lastEventId);
+      } finally {
+        client.close();
+        await manager.deleteConversation(conversation.id).catch(() => undefined);
+      }
+    },
+    config.testTimeout
+  );
+
+  it(
+    'navigate 404s for an unknown conversation and an unknown event id',
+    async () => {
+      // Both not-found branches of the navigate route. A well-formed but
+      // non-existent conversation UUID reaches the handler -> "Conversation not
+      // found" 404. A real conversation with a bogus event_id hits the server's
+      // event_id ValueError branch -> 404 (not a 500). Together they confirm the
+      // route template resolves and both not-found paths are wired.
+      const client = new ConversationClient({ host: config.agentServerUrl });
+      const missingId = '00000000-0000-0000-0000-000000000000';
+      const conversation = await manager.createConversation(createDummyAgent(), {
+        workingDir: config.agentWorkspaceDir,
+      });
+      try {
+        let unknownConversationStatus: number | undefined;
+        try {
+          await client.navigateConversation(missingId, { event_id: null });
+        } catch (error) {
+          expect(error).toBeInstanceOf(HttpError);
+          unknownConversationStatus = (error as HttpError).status;
+        }
+        expect(unknownConversationStatus).toBe(404);
+
+        let unknownEventStatus: number | undefined;
+        try {
+          await client.navigateConversation(conversation.id, {
+            event_id: 'event-that-does-not-exist',
+          });
+        } catch (error) {
+          expect(error).toBeInstanceOf(HttpError);
+          unknownEventStatus = (error as HttpError).status;
+        }
+        expect(unknownEventStatus).toBe(404);
+      } finally {
+        client.close();
+        await manager.deleteConversation(conversation.id).catch(() => undefined);
+      }
+    },
+    config.testTimeout
+  );
 });

--- a/src/client/conversation-client.ts
+++ b/src/client/conversation-client.ts
@@ -12,6 +12,7 @@ import type {
   ConversationSearchRequest,
   ConversationSearchResponse,
   ForkConversationRequest,
+  NavigateConversationRequest,
   SetConfirmationPolicyRequest,
   SetSecurityAnalyzerRequest,
   StartGoalRequest,
@@ -307,6 +308,34 @@ export class ConversationClient {
   ): Promise<TConversation> {
     const response = await this.client.post<TConversation>(
       `/api/conversations/${conversationId}/fork`,
+      request,
+      {
+        params:
+          options.includeSkills === undefined
+            ? undefined
+            : { include_skills: options.includeSkills },
+      }
+    );
+    return response.data;
+  }
+
+  /**
+   * Move a conversation's HEAD to an existing event, re-rooting the active
+   * branch the agent runs on next. Unlike {@link forkConversation}, this
+   * creates no new conversation — all branches stay on disk. Pass
+   * `{ event_id: null }` (or an empty request) to select the empty tree.
+   *
+   * Returns the updated {@link ConversationInfo}, carrying the new
+   * `leaf_event_id`. The server answers 404 for an unknown conversation or an
+   * unknown `event_id`.
+   */
+  async navigateConversation<TConversation = ConversationInfo>(
+    conversationId: string,
+    request: NavigateConversationRequest = {},
+    options: { includeSkills?: boolean } = {}
+  ): Promise<TConversation> {
+    const response = await this.client.post<TConversation>(
+      `/api/conversations/${conversationId}/navigate`,
       request,
       {
         params:

--- a/src/conversation/remote-conversation.ts
+++ b/src/conversation/remote-conversation.ts
@@ -31,6 +31,7 @@ import {
   SetSecurityAnalyzerRequest,
   AgentResponseResult,
   ForkConversationRequest,
+  NavigateConversationRequest,
   StartGoalRequest,
 } from '../models/conversation';
 import { IConversation, BaseConversationOptions } from './base';
@@ -369,6 +370,22 @@ export class RemoteConversation implements IConversation {
       onError: this.onError,
       hookConfig: response.data.hook_config ?? this.hookConfig,
     });
+  }
+
+  /**
+   * Move this conversation's HEAD to an existing event, re-rooting the active
+   * branch in place. Unlike {@link fork}, this creates no new conversation —
+   * all branches stay on disk and only the branch the agent runs on next
+   * changes. Pass `null` to select the empty tree (a deliberate new root).
+   *
+   * The cached state is refreshed afterwards so a subsequent `state` read
+   * reflects the new HEAD — `leaf_event_id` is not broadcast over the
+   * WebSocket. Throws on 404 if the server rejects the event id.
+   */
+  async navigateTo(eventId: string | null): Promise<void> {
+    const request: NavigateConversationRequest = { event_id: eventId };
+    await this.client.post(`/api/conversations/${this.id}/navigate`, request);
+    await this.state.refresh();
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,7 @@ export type {
   ConversationEventSearchOptions,
   ConversationEventCountOptions,
   ForkConversationRequest,
+  NavigateConversationRequest,
   AgentResponseResult,
   ConversationEvent as ConversationApiEvent,
   ConversationEventPage,

--- a/src/models/conversation.ts
+++ b/src/models/conversation.ts
@@ -53,6 +53,13 @@ export interface ConversationInfo {
   updated_at?: string;
   tags?: Record<string, string>;
   /**
+   * HEAD of the conversation tree: the parent of the next appended event.
+   * `null` means an empty tree (or, for pre-feature conversations, the linear
+   * tail). Moving it via `navigate` re-roots the active branch the agent runs
+   * on. See {@link ConversationClient.navigateConversation}.
+   */
+  leaf_event_id?: string | null;
+  /**
    * Provenance of the agent profile that launched this conversation.
    * Present when the conversation was started via `agent_profile_id`; absent
    * for conversations started directly with `agent` or `agent_settings`.
@@ -216,6 +223,19 @@ export interface ForkConversationRequest {
   title?: string;
   tags?: Record<string, string>;
   reset_metrics?: boolean;
+}
+
+/**
+ * Payload to move a conversation's HEAD to an existing event (in-place
+ * re-root). Unlike a fork, this creates no new conversation — all branches
+ * stay on disk and only the active branch the agent runs on next changes.
+ */
+export interface NavigateConversationRequest {
+  /**
+   * Event to make the new HEAD, re-rooting the active branch. Omit or pass
+   * `null` to select the empty tree (a deliberate new root).
+   */
+  event_id?: string | null;
 }
 
 export interface AgentResponseResult {


### PR DESCRIPTION
## Summary

Adds client support for `POST /api/conversations/{id}/navigate` (agent-server / software-agent-sdk #3923, released in v1.31.0). Navigate moves a conversation's HEAD to an existing event, re-rooting the active branch the agent runs on next — all branches stay on disk and, unlike `fork`, no new conversation is created. Mirrors the Python SDK's `RemoteConversation.navigate_to`.

## Changes

- **`ConversationClient.navigateConversation(id, request?, { includeSkills? })`** — `POST .../navigate`, returns the updated `ConversationInfo` carrying the new `leaf_event_id`. Follows the `forkConversation` template.
- **`RemoteConversation.navigateTo(eventId)`** — ergonomic wrapper that posts and then refreshes cached state (`leaf_event_id` is not broadcast over the WebSocket), matching the Python SDK.
- **Types** — `NavigateConversationRequest { event_id?: string | null }` and an explicit `leaf_event_id?: string | null` on `ConversationInfo`. `event_id: null` selects the empty tree (a deliberate new root).

## Tests

- **Unit** (`api-clients.test.ts`): client-level navigate with `include_skills`, navigate-to-null, and the `navigateTo` wrapper (POST + state refresh).
- **Integration** (`deterministic-api.integration.test.ts`): re-roots HEAD across two real events and back to the empty tree, plus 404 contract guards for an unknown conversation and an unknown `event_id`.

## Verification

- `tsc --noEmit`, `eslint`, `prettier --check`: clean
- Unit suite: all pass
- Integration: ran against `ghcr.io/openhands/agent-server:1.31.0-python` (the pinned CI image) — deterministic suite green, including the two navigate tests.
