### PR TITLE
fix: make published package root importable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       
     - name: Run type check
       run: npm run build
+
+    - name: Run package install smoke test
+      run: npm run test:git-dependency
       
     - name: Run tests
       run: npm run test:coverage

--- a/scripts/smoke-test-git-dependency.mjs
+++ b/scripts/smoke-test-git-dependency.mjs
@@ -36,11 +36,12 @@ try {
       '--input-type=module',
       '-e',
       [
+        "import { Agent, RemoteWorkspace as RootRemoteWorkspace } from '@openhands/typescript-client';",
         "import { ServerClient } from '@openhands/typescript-client/clients';",
         "import { HttpClient } from '@openhands/typescript-client/client/http-client';",
         "import { RemoteEventsList } from '@openhands/typescript-client/events/remote-events-list';",
         "import { RemoteWorkspace } from '@openhands/typescript-client/workspace/remote-workspace';",
-        'console.log(typeof ServerClient, typeof HttpClient, typeof RemoteEventsList, typeof RemoteWorkspace);',
+        'console.log(typeof Agent, typeof RootRemoteWorkspace, typeof ServerClient, typeof HttpClient, typeof RemoteEventsList, typeof RemoteWorkspace);',
       ].join('\n'),
     ],
     {

--- a/src/__tests__/acp-providers.test.ts
+++ b/src/__tests__/acp-providers.test.ts
@@ -1,4 +1,6 @@
 import { ACP_PROVIDERS, getAcpProvider } from '../index';
+import providersJson from '../models/acp-providers.json';
+import { ACP_PROVIDER_DATA } from '../models/acp-providers-data';
 import type { ACPProviderKey } from '../index';
 
 /**
@@ -9,6 +11,10 @@ import type { ACPProviderKey } from '../index';
  * `api_key_env_var`, `base_url_env_var`, and `file_secrets`.
  */
 describe('ACP provider credential descriptors', () => {
+  it('keeps the runtime provider data in sync with the JSON drift-check mirror', () => {
+    expect(ACP_PROVIDER_DATA).toEqual(providersJson);
+  });
+
   const KEYS: ACPProviderKey[] = ['claude-code', 'codex', 'gemini-cli'];
 
   it('exposes an entry for each built-in provider', () => {

--- a/src/models/acp-providers-data.ts
+++ b/src/models/acp-providers-data.ts
@@ -1,0 +1,130 @@
+export const ACP_PROVIDER_DATA = {
+  'claude-code': {
+    key: 'claude-code',
+    display_name: 'Claude Code',
+    default_command: ['npx', '-y', '@agentclientprotocol/claude-agent-acp@0.44.0'],
+    api_key_env_var: 'ANTHROPIC_API_KEY',
+    base_url_env_var: 'ANTHROPIC_BASE_URL',
+    default_session_mode: 'bypassPermissions',
+    agent_name_patterns: ['claude-agent'],
+    supports_set_session_model: true,
+    session_meta_key: 'claudeCode',
+    available_models: [
+      {
+        id: 'default',
+        label: 'Default (recommended)',
+      },
+      {
+        id: 'opus[1m]',
+        label: 'Claude Opus 4.8 (1M)',
+      },
+      {
+        id: 'sonnet',
+        label: 'Claude Sonnet 4.6',
+      },
+      {
+        id: 'haiku',
+        label: 'Claude Haiku 4.5',
+      },
+    ],
+    default_model: 'opus[1m]',
+    supports_runtime_model_switch: true,
+    file_secrets: [],
+    binary_name: 'claude-agent-acp',
+    data_dir_env_var: 'CLAUDE_CONFIG_DIR',
+  },
+  codex: {
+    key: 'codex',
+    display_name: 'Codex',
+    default_command: ['npx', '-y', '@zed-industries/codex-acp@0.16.0'],
+    api_key_env_var: 'OPENAI_API_KEY',
+    base_url_env_var: 'OPENAI_BASE_URL',
+    default_session_mode: 'full-access',
+    agent_name_patterns: ['codex-acp'],
+    supports_set_session_model: true,
+    session_meta_key: null,
+    available_models: [
+      {
+        id: 'gpt-5.5',
+        label: 'GPT-5.5',
+      },
+      {
+        id: 'gpt-5.4',
+        label: 'GPT-5.4',
+      },
+      {
+        id: 'gpt-5.4-mini',
+        label: 'GPT-5.4 Mini',
+      },
+    ],
+    default_model: 'gpt-5.5',
+    supports_runtime_model_switch: true,
+    file_secrets: [
+      {
+        secret_name: 'CODEX_AUTH_JSON',
+        filename: 'auth.json',
+        env_var: 'CODEX_HOME',
+        subdir: 'codex',
+        env_points_to: 'dir',
+        warn_if_unset: [],
+      },
+    ],
+    binary_name: 'codex-acp',
+    data_dir_env_var: 'CODEX_HOME',
+  },
+  'gemini-cli': {
+    key: 'gemini-cli',
+    display_name: 'Gemini CLI',
+    default_command: ['npx', '-y', '@google/gemini-cli@0.46.0', '--acp'],
+    api_key_env_var: 'GEMINI_API_KEY',
+    base_url_env_var: 'GEMINI_BASE_URL',
+    default_session_mode: 'default',
+    agent_name_patterns: ['gemini-cli'],
+    supports_set_session_model: true,
+    session_meta_key: null,
+    available_models: [
+      {
+        id: 'auto',
+        label: 'Auto',
+      },
+      {
+        id: 'gemini-3.1-pro-preview',
+        label: 'Gemini 3.1 Pro (preview)',
+      },
+      {
+        id: 'gemini-3-pro-preview',
+        label: 'Gemini 3 Pro (preview)',
+      },
+      {
+        id: 'gemini-3-flash-preview',
+        label: 'Gemini 3 Flash (preview)',
+      },
+      {
+        id: 'gemini-3.1-flash-lite',
+        label: 'Gemini 3.1 Flash Lite',
+      },
+      {
+        id: 'gemini-2.5-pro',
+        label: 'Gemini 2.5 Pro',
+      },
+      {
+        id: 'gemini-2.5-flash',
+        label: 'Gemini 2.5 Flash',
+      },
+    ],
+    default_model: 'auto',
+    supports_runtime_model_switch: true,
+    file_secrets: [
+      {
+        secret_name: 'GOOGLE_APPLICATION_CREDENTIALS_JSON',
+        filename: 'gcloud-credentials.json',
+        env_var: 'GOOGLE_APPLICATION_CREDENTIALS',
+        subdir: 'gemini-cli',
+        env_points_to: 'file',
+        warn_if_unset: ['GOOGLE_CLOUD_PROJECT', 'GOOGLE_CLOUD_LOCATION'],
+      },
+    ],
+    binary_name: 'gemini',
+    data_dir_env_var: 'HOME',
+  },
+} as const;

--- a/src/models/acp.ts
+++ b/src/models/acp.ts
@@ -4,14 +4,13 @@
  * `openhands.sdk.settings.acp_providers.ACP_PROVIDERS` in
  * https://github.com/OpenHands/software-agent-sdk.
  *
- * The data lives in `./acp-providers.json` so the Python drift check in
- * `scripts/check-acp-drift.py` can read it without executing TypeScript.
- * To add or modify a provider, edit `acp_providers.py` in software-agent-sdk
- * first, then mirror the change in `acp-providers.json` here. CI will fail
- * until the two match.
+ * The JSON mirror in `./acp-providers.json` lets the Python drift check in
+ * `scripts/check-acp-drift.py` read provider data without executing TypeScript.
+ * Runtime code imports `./acp-providers-data` instead of JSON so the published
+ * ESM package loads in Node.js without JSON import attributes.
  */
 
-import providersData from './acp-providers.json';
+import { ACP_PROVIDER_DATA } from './acp-providers-data';
 
 /**
  * Stable registry key for a built-in ACP provider.
@@ -104,7 +103,7 @@ export interface ACPProviderInfo {
 }
 
 export const ACP_PROVIDERS: Readonly<Record<ACPProviderKey, ACPProviderInfo>> =
-  providersData as Readonly<Record<ACPProviderKey, ACPProviderInfo>>;
+  ACP_PROVIDER_DATA as Readonly<Record<ACPProviderKey, ACPProviderInfo>>;
 
 /**
  * Return the {@link ACPProviderInfo} for `key`, or `null` if unknown.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

Issue #135 asks whether publishing `@openhands/typescript-client` is solved. Investigation found the package is published to npm as `1.28.0` with the expected subpath exports and publish workflows, but the published root import currently fails in Node ESM because `dist/models/acp.js` imports `acp-providers.json` without a JSON import attribute.

Fixes #135.

## Summary

- Move ACP runtime provider data into a TypeScript module so published ESM no longer imports JSON at runtime.
- Keep the JSON mirror for the existing Python drift check and add a test that verifies it stays in sync with the runtime TS data.
- Extend the package install smoke test to import the root package and run that smoke test in CI.

## Issue Number

Fixes #135

## How to Test

- `npm run build`
- `npm run lint` (passes with existing warnings)
- `npm run test:coverage`
- `npm run format:check`
- `npm run test:git-dependency`
- Packed local tarball and verified these imports resolve:
  - `@openhands/typescript-client`
  - `@openhands/typescript-client/clients`
  - `@openhands/typescript-client/client/http-client`
  - `@openhands/typescript-client/events/remote-events-list`
  - `@openhands/typescript-client/workspace/remote-workspace`

## Video/Screenshots

N/A — package/runtime import fix only.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Current package shape from the investigation:

- `@openhands/typescript-client@1.28.0` is published on npm: https://www.npmjs.com/package/@openhands/typescript-client
- `package.json` exports include `.`, `./clients`, `./client/http-client`, `./events/remote-events-list`, and `./workspace/remote-workspace`.
- Release automation exists for npm trusted publishing and GitHub Packages.
- The package tarball currently includes `dist/**/*`, including generated test helper files under `dist/__tests__`; this PR does not change that packaging surface.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/31f717ee-8c63-4ee0-943e-94409c3375c0)