### PR TITLE
fix: expose GPT-5.6 Codex models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,27 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Resolve openhands-sdk source
+      id: sdk-source
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_BODY: ${{ github.event.pull_request.body || '' }}
+      run: |
+        sdk_repo=OpenHands/software-agent-sdk
+        sdk_ref=main
+        if [[ "$PR_BODY" =~ github.com/OpenHands/software-agent-sdk/pull/([0-9]+) ]]; then
+          sdk_pr=${BASH_REMATCH[1]}
+          sdk_metadata=$(gh api "repos/OpenHands/software-agent-sdk/pulls/$sdk_pr")
+          sdk_repo=$(jq -r '.head.repo.full_name' <<< "$sdk_metadata")
+          sdk_ref=$(jq -r '.head.sha' <<< "$sdk_metadata")
+        fi
+        echo "repo=$sdk_repo" >> "$GITHUB_OUTPUT"
+        echo "ref=$sdk_ref" >> "$GITHUB_OUTPUT"
+
     - name: Install openhands-sdk
-      run: pip install -r scripts/requirements-acp-check.txt
+      run: >-
+        pip install
+        "openhands-sdk @ git+https://github.com/${{ steps.sdk-source.outputs.repo }}@${{ steps.sdk-source.outputs.ref }}#subdirectory=openhands-sdk"
 
     - name: Check ACP_PROVIDERS matches openhands-sdk
       env:

--- a/scripts/requirements-acp-check.txt
+++ b/scripts/requirements-acp-check.txt
@@ -1,5 +1,6 @@
 # Pinned dependency for scripts/check-acp-drift.py.
 # Tracks `main` of OpenHands/software-agent-sdk intentionally: the drift
 # check exists to fail CI when ACP_PROVIDERS moves upstream so this repo's
-# JSON mirror gets updated. Do NOT pin to a tag or sha.
+# JSON mirror gets updated. Do NOT pin to a tag or sha. CI resolves a companion
+# SDK PR linked in the TypeScript client PR description before installing.
 openhands-sdk @ git+https://github.com/OpenHands/software-agent-sdk@main#subdirectory=openhands-sdk

--- a/src/__tests__/acp-providers.test.ts
+++ b/src/__tests__/acp-providers.test.ts
@@ -39,6 +39,15 @@ describe('ACP provider credential descriptors', () => {
     expect(provider.base_url_env_var).toBe(baseUrlEnvVar);
   });
 
+  it('uses the maintained Codex adapter and exposes GPT-5.6 models', () => {
+    const codex = ACP_PROVIDERS.codex;
+    expect(codex.default_command).toEqual(['npx', '-y', '@agentclientprotocol/codex-acp@1.1.2']);
+    expect(codex.default_session_mode).toBe('agent-full-access');
+    expect(codex.available_models.map((model) => model.id)).toEqual(
+      expect.arrayContaining(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])
+    );
+  });
+
   describe('file_secrets', () => {
     it('claude-code authenticates via env var only (no file secrets)', () => {
       expect(ACP_PROVIDERS['claude-code'].file_secrets).toEqual([]);

--- a/src/models/acp-providers.json
+++ b/src/models/acp-providers.json
@@ -36,14 +36,30 @@
   "codex": {
     "key": "codex",
     "display_name": "Codex",
-    "default_command": ["npx", "-y", "@zed-industries/codex-acp@0.16.0"],
+    "default_command": ["npx", "-y", "@agentclientprotocol/codex-acp@1.1.2"],
     "api_key_env_var": "OPENAI_API_KEY",
     "base_url_env_var": "OPENAI_BASE_URL",
-    "default_session_mode": "full-access",
+    "default_session_mode": "agent-full-access",
     "agent_name_patterns": ["codex-acp"],
     "supports_set_session_model": true,
     "session_meta_key": null,
     "available_models": [
+      {
+        "id": "gpt-5.6",
+        "label": "GPT-5.6"
+      },
+      {
+        "id": "gpt-5.6-sol",
+        "label": "GPT-5.6 Sol"
+      },
+      {
+        "id": "gpt-5.6-terra",
+        "label": "GPT-5.6 Terra"
+      },
+      {
+        "id": "gpt-5.6-luna",
+        "label": "GPT-5.6 Luna"
+      },
       {
         "id": "gpt-5.5",
         "label": "GPT-5.5"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

I tested this through the agent canvas and it works.

- [x] A human has tested these changes.

---

## Why

The TypeScript client's generated ACP provider registry still pinned the retired Codex ACP adapter, so Agent Canvas could not offer the current GPT-5.6 model family before a session started.

## Summary

- mirror the SDK's `@agentclientprotocol/codex-acp@1.1.2` command and `agent-full-access` mode
- expose GPT-5.6, Sol, Terra, and Luna in the generated Codex model registry
- cover the adapter contract and model IDs in the registry test
- validate registry changes against the immutable head SHA of a companion SDK PR linked in this description

## Issue Number

N/A

## How to Test

- `npm run lint` (0 errors; 17 pre-existing warnings)
- `npm run build`
- `npm run test:coverage` (284 passed)
- `npm run format:check`
- `uv run python /home/gneubig/work/typescript-client/scripts/check-acp-drift.py` from the companion SDK checkout (registry matches all 3 providers)
- installed the companion SDK PR through the same Git URL resolved by CI and reran `scripts/check-acp-drift.py` (passed)

## Video/Screenshots

Not applicable; this PR mirrors generated provider metadata. End-to-end GPT-5.6 QA is documented in the companion SDK PR.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Companion SDK PR: https://github.com/OpenHands/software-agent-sdk/pull/4056

Closes #273

<!-- Issue association added by OpenHands AI agent on behalf of Graham. -->