### PR TITLE
test: cover package root import in git-dependency smoke test

### DIFF
--- a/scripts/smoke-test-git-dependency.mjs
+++ b/scripts/smoke-test-git-dependency.mjs
@@ -36,12 +36,19 @@ try {
       '--input-type=module',
       '-e',
       [
+        // Root import must load without a JSON import attribute error
+        // (ERR_IMPORT_ATTRIBUTE_MISSING). The barrel transitively loads
+        // `models/acp.js`, which imports `acp-providers.json`; the published
+        // ESM must carry `with { type: 'json' }` on that import. Touching
+        // ACP_PROVIDERS forces that module to actually evaluate.
+        "import { ACP_PROVIDERS } from '@openhands/typescript-client';",
         "import { ServerClient } from '@openhands/typescript-client/clients';",
         "import { HttpClient } from '@openhands/typescript-client/client/http-client';",
         "import { isOpenHandsCloudHost } from '@openhands/typescript-client/client/device-flow-client';",
         "import { RemoteEventsList } from '@openhands/typescript-client/events/remote-events-list';",
         "import { RemoteWorkspace } from '@openhands/typescript-client/workspace/remote-workspace';",
-        'console.log(typeof ServerClient, typeof HttpClient, typeof isOpenHandsCloudHost, typeof RemoteEventsList, typeof RemoteWorkspace);',
+        "if (!ACP_PROVIDERS || typeof ACP_PROVIDERS !== 'object') { throw new Error('ACP_PROVIDERS did not load from the root import'); }",
+        'console.log(typeof ServerClient, typeof HttpClient, typeof isOpenHandsCloudHost, typeof RemoteEventsList, typeof RemoteWorkspace, Object.keys(ACP_PROVIDERS).length);',
       ].join('\n'),
     ],
     {


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Issue #135 ("Publish `@openhands/typescript-client` as an npm package") is functionally resolved as of `@openhands/typescript-client@1.34.0`: the package is published to the public npm registry, the `vendor/` directory and `file:` reference are gone, and a clean Node ESM project can `npm install` it and import the root plus every subpath export.

The last blocker was the **package root import** failing with `ERR_IMPORT_ATTRIBUTE_MISSING`. The root barrel transitively loads `models/acp.js`, which imports `acp-providers.json`; in published ESM that import must carry a `with { type: 'json' }` attribute (added by `scripts/rewrite-relative-imports.mjs` during the build). That fix is already in the tree and verified in the build output (`dist/models/acp.js`), but the existing git-dependency smoke test only exercised the **subpath** exports (`./clients`, `./client/http-client`, `./events/remote-events-list`, `./workspace/remote-workspace`) — never the root `.`, which was the exact import that used to crash. That left the regression uncovered.

This PR closes that coverage gap so the fix can't silently regress.

## Summary

- Add the package **root** import (`import { ACP_PROVIDERS } from '@openhands/typescript-client'`) to `scripts/smoke-test-git-dependency.mjs`.
- Touch the JSON-backed `ACP_PROVIDERS` export (and assert it loaded) so the smoke test fails loudly if the `with { type: 'json' }` attribute regresses and the root import throws `ERR_IMPORT_ATTRIBUTE_MISSING` again.

## Issue Number

Fixes #135

## How to Test

```bash
npm ci
npm run build
npm run test:git-dependency
```

The smoke test installs the package as a git dependency into a temp ESM project and imports the root + all subpaths. It prints the resolved export types and the ACP provider count, and throws if the root import fails to load the JSON-backed registry.

Additionally verified manually against a packed tarball in a clean `type: module` project:

```
root keys: 88
ACP_PROVIDERS: true
clients: 34
http-client: 2
remote-events-list: 1
remote-workspace: 1
ALL IMPORTS OK
```

Full local check suite also passes: `npm run lint` (0 errors), `npm run format:check`, `npm run build`, and `npm run test` (290 tests).

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This is a test-only change; no runtime/library code is modified. The underlying JSON import-attribute fix already shipped in `1.34.0` — this simply pins the regression so future changes to the build/rewrite step keep the root import working.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@VascoSch92 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ab84be76-a29f-4eec-b906-6960efb0e8b4)